### PR TITLE
Added new tome for printing process list as a tree (#423)

### DIFF
--- a/tavern/tomes/process_tree/main.eldritch
+++ b/tavern/tomes/process_tree/main.eldritch
@@ -1,0 +1,80 @@
+def pad_pid(pid):
+    pid_column_width = 16
+    padding = pid_column_width - len(pid)
+    return pid +  " "*padding
+
+def pad_username (username):
+    username_column_width = 32
+    padding = username_column_width - len(username)
+    return username +  " "*padding
+
+def depth_first_search(visited, process_tree, current_proc_pid, padding, process_list_dictionary):
+    if current_proc_pid not in visited:
+
+        padding_string = ""
+
+        if padding > 0:
+            padding_string = (padding - 1) * "  " + " \_ "
+
+        if current_proc_pid != "0":
+            print(pad_pid(current_proc_pid))
+            print(pad_pid(process_list_dictionary[current_proc_pid]["ppid"]))
+            print(pad_username(process_list_dictionary[current_proc_pid]["username"]))
+            print(padding_string + process_list_dictionary[current_proc_pid]["command"].replace("\n","\\n")+"\n")
+
+        padding = padding + 1
+
+        visited.append(current_proc_pid)
+
+        for process_pid in process_tree[current_proc_pid]:
+            depth_first_search(visited, process_tree, process_pid, padding, process_list_dictionary)
+
+def process_tree(cmd_substring):
+
+    if cmd_substring == '*':
+        cmd_substring = ''
+
+    procs = process.list()
+
+    print(pad_pid("PID"))
+    print(pad_pid("PPID")) 
+    print(pad_username("username"))
+    print("command\n")
+
+    process_list_dictionary = {}
+
+    process_tree = {}
+
+    for proc in procs:
+        if cmd_substring in proc['command']:
+            current_proc_command = proc['command']
+            if current_proc_command == "":
+                current_proc_command = proc['name']
+
+            current_proc_pid = str(proc['pid'])
+            current_proc_ppid = str(proc['ppid'])
+            current_proc_username = proc['username']
+
+            current_process_content = {
+                "ppid": current_proc_ppid,
+                "username": current_proc_username,
+                "command": current_proc_command
+            }
+            process_list_dictionary[current_proc_pid] = current_process_content
+
+            if current_proc_pid not in process_tree:
+                process_tree[current_proc_pid] = []
+
+            if current_proc_ppid in process_tree:
+                process_tree[current_proc_ppid].append(current_proc_pid)
+            else:
+                process_tree[current_proc_ppid] = []
+            
+    visited = []
+
+    for pid in process_tree:
+        depth_first_search(visited, process_tree, pid, 0, process_list_dictionary)
+
+process_tree(input_params['cmd_substring'])
+print("\n")
+print("\n")

--- a/tavern/tomes/process_tree/metadata.yml
+++ b/tavern/tomes/process_tree/metadata.yml
@@ -1,0 +1,7 @@
+name: Process tree
+description: Get a tree view of running processes
+paramdefs:
+- name: cmd_substring
+  label: Process search string
+  type: string
+  placeholder: process name substring eg. sh match bash and sh or * for all


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Created a new tome for printing process list as a tree. Process list will be output in the following format - 

```bash
PID             PPID            username                        command
1               0               root                            /lib/systemd/systemd --system --deserialize 44
2               1               root                             \_ /init
5               2               root                               \_ plan9 --control-socket 6 --log-level 4 --server-fd 7 --pipe-fd 9 --log-truncate
542             2               root                               \_ /init
349448          2               root                               \_ /init
354             2               root                               \_ /bin/login -f
349435          2               root                               \_ /init
391011          730             ubuntu                          sudo go run ./tavern
```

#### Which issue(s) this PR fixes:
Fixes #423 