### PR TITLE
513 update file tree tome to default exclude extraneous dirs

### DIFF
--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -26,7 +26,8 @@ struct Handle {
 async fn run_tomes(tomes: Vec<ParsedTome>) -> Result<Vec<String>> {
     let mut handles = Vec::new();
     for tome in tomes {
-        let (runtime, output) = Runtime::new();
+        let (mut runtime, output) = Runtime::new();
+        runtime.stdout_reporting = true;
         let handle = tokio::task::spawn_blocking(move || {
             runtime.run(Tome {
                 eldritch: tome.eldritch,
@@ -58,7 +59,7 @@ async fn run_tomes(tomes: Vec<ParsedTome>) -> Result<Vec<String>> {
         if !errors.is_empty() {
             return Err(anyhow!("tome execution failed: {:?}", errors));
         }
-        println!("OUTPUT: {:?}", out);
+        println!("OUTPUT:\n{}", out.join(""));
         result.append(&mut out);
     }
 

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -27,7 +27,7 @@ async fn run_tomes(tomes: Vec<ParsedTome>) -> Result<Vec<String>> {
     let mut handles = Vec::new();
     for tome in tomes {
         let (mut runtime, output) = Runtime::new();
-        runtime.stdout_reporting = true;
+        runtime.with_stdout_reporting();
         let handle = tokio::task::spawn_blocking(move || {
             runtime.run(Tome {
                 eldritch: tome.eldritch,

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -59,7 +59,6 @@ async fn run_tomes(tomes: Vec<ParsedTome>) -> Result<Vec<String>> {
         if !errors.is_empty() {
             return Err(anyhow!("tome execution failed: {:?}", errors));
         }
-        println!("OUTPUT:\n{}", out.join(""));
         result.append(&mut out);
     }
 

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -108,9 +108,6 @@ fn main() -> anyhow::Result<()> {
             }
         };
 
-        if !result.is_empty() {
-            println!("{:?}", result);
-        }
         process::exit(error_code);
     } else if matches.contains_id("interactive") {
         inter::interactive_main()?;

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> anyhow::Result<()> {
             .build()
             .unwrap();
 
-        let (error_code, result) = match runtime.block_on(run_tomes(parsed_tomes)) {
+        let (error_code, _result) = match runtime.block_on(run_tomes(parsed_tomes)) {
             Ok(response) => (0, response),
             Err(error) => {
                 eprint!("failed to execute tome {:?}", error);

--- a/implants/golem/tests/cli.rs
+++ b/implants/golem/tests/cli.rs
@@ -30,9 +30,9 @@ fn test_golem_main_syntax_fail() -> anyhow::Result<()> {
     let mut cmd = Command::cargo_bin("golem")?;
 
     cmd.arg(format!("{GOLEM_CLI_TEST_DIR}syntax_fail.tome"));
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains(r#"Parse error: unexpected string literal "win" here"#.to_string()));
+    cmd.assert().failure().stderr(predicate::str::contains(
+        r#"Parse error: unexpected string literal "win" here"#.to_string(),
+    ));
 
     Ok(())
 }
@@ -45,7 +45,7 @@ fn test_golem_main_basic_non_interactive() -> anyhow::Result<()> {
     cmd.arg(format!("{GOLEM_CLI_TEST_DIR}hello_world.tome"));
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("[\"HELLO\"]"));
+        .stdout(predicate::str::contains(r#"["HELLO"]"#));
 
     Ok(())
 }
@@ -58,7 +58,7 @@ fn test_golem_main_basic_eldritch_non_interactive() -> anyhow::Result<()> {
     cmd.arg(format!("{GOLEM_CLI_TEST_DIR}eldritch_test.tome"));
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains(r#"[\"append\", \"compress\""#));
+        .stdout(predicate::str::contains(r#"["append", "compress""#));
 
     Ok(())
 }

--- a/implants/golem/tests/cli.rs
+++ b/implants/golem/tests/cli.rs
@@ -45,7 +45,7 @@ fn test_golem_main_basic_non_interactive() -> anyhow::Result<()> {
     cmd.arg(format!("{GOLEM_CLI_TEST_DIR}hello_world.tome"));
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains(r#"["HELLO"]"#));
+        .stdout(predicate::str::contains(r#"HELLO"#));
 
     Ok(())
 }

--- a/implants/lib/eldritch/src/runtime.rs
+++ b/implants/lib/eldritch/src/runtime.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
  */
 #[derive(ProvidesStaticType)]
 pub struct Runtime {
-    pub stdout_reporting: bool,
+    stdout_reporting: bool,
 
     ch_exec_started_at: Sender<Timestamp>,
     ch_exec_finished_at: Sender<Timestamp>,

--- a/implants/lib/eldritch/src/runtime.rs
+++ b/implants/lib/eldritch/src/runtime.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
  */
 #[derive(ProvidesStaticType)]
 pub struct Runtime {
-    stdout_reporting: bool,
+    pub stdout_reporting: bool,
 
     ch_exec_started_at: Sender<Timestamp>,
     ch_exec_finished_at: Sender<Timestamp>,
@@ -174,13 +174,11 @@ impl Runtime {
     fn parse(tome: &Tome) -> Result<AstModule> {
         match AstModule::parse("main", tome.eldritch.to_string(), &Dialect::Extended) {
             Ok(res) => Ok(res),
-            Err(err) => {
-                Err(anyhow::anyhow!(
-                    "[eldritch] Unable to parse eldritch tome: {}: {}",
-                    err.to_string(),
-                    tome.eldritch.to_string(),
-                ))
-            }
+            Err(err) => Err(anyhow::anyhow!(
+                "[eldritch] Unable to parse eldritch tome: {}: {}",
+                err.to_string(),
+                tome.eldritch.to_string(),
+            )),
         }
     }
 

--- a/tavern/tomes/file_tree/main.eldritch
+++ b/tavern/tomes/file_tree/main.eldritch
@@ -28,7 +28,6 @@ def main(path):
     elif file.is_file(path):
         print("Error: Invalid Path ("+path+")\n")
 
-input_params['path']="/"
 main(input_params['path'])
 print("\n")
 print("\n")

--- a/tavern/tomes/file_tree/main.eldritch
+++ b/tavern/tomes/file_tree/main.eldritch
@@ -1,34 +1,32 @@
-block_list = ["/proc","/sys","/lib","/libx32","/lib32","/lib64","/boot","/srv","/snap","/run","/dev","/cores"]
+block_list = ["/proc","/sys","/lib","/libx32","/lib32","/lib64","/boot","/srv","/usr","/snap","/run","/dev","/cores"]
+
 
 def file_list(path,tree):
     tree="|\t"+tree
-    if file.is_dir(path):
-        files = file.list(path)
-        for f in files:
-            type_str = ""
-            if f['type'] == "Directory":
-                print(tree+"|---"+path+"/"+f['file_name']+"\n")
-                file_list(path+"/"+f['file_name'],tree)
-            if f['type'] == "Link":
-                print(tree+"|---"+f['file_name']+"\n")
-            if f['type'] == "File":
-                print(tree+"|---"+f['file_name']+"\n")
-    else:
-        print("Error: Invalid Path ("+path+")\n")
+    files = file.list(path)
+    for f in files:
+        if path+f['file_name'] in block_list:
+            print("Skipping: "+path+f['file_name']+"\n")
+            continue
+        if f['type'] == "Directory":
+            print(tree+"|---"+path+"/"+f['file_name']+"\n")
+            file_list(path+"/"+f['file_name'],tree)
+        if f['type'] == "Link":
+            print(tree+"|---"+f['file_name']+"\n")
+        if f['type'] == "File":
+            print(tree+"|---"+f['file_name']+"\n")
 
 def main(path):
     tree=""
-    print(path+"\n")
-    if path == "/":
-        print("It looks like you're trying to list every file on the system.\n")
-        print("This generates a lot of data so I'm going to exclude less helpful directories\n")
-        print("If you really really want everything including /proc and /sys specify \"//\"\n")
-        files = file.list(path)
-        for f in files:
-            if f['file_name'] not in block_list:
-                file_list("/"+f['file_name'],tree)
-    else:
+    if file.is_dir(path):
+        print(path+"\n")
+        if path == "/":
+            print("It looks like you're trying to list every file on the system.\n")
+            print("This generates a lot of data so I'm going to exclude less helpful directories\n")
+            print("If you really really want everything including /proc and /sys specify \"//\"\n")
         file_list(path,tree)
+    elif file.is_file(path):
+        print("Error: Invalid Path ("+path+")\n")
 
 input_params['path']="/"
 main(input_params['path'])

--- a/tavern/tomes/file_tree/main.eldritch
+++ b/tavern/tomes/file_tree/main.eldritch
@@ -1,5 +1,7 @@
+block_list = ["/proc","/sys","/lib","/libx32","/lib32","/lib64","/boot","/srv","/snap","/run","/dev","/cores"]
+
 def file_list(path,tree):
-    tree="|\t\t"+tree
+    tree="|\t"+tree
     if file.is_dir(path):
         files = file.list(path)
         for f in files:
@@ -14,8 +16,21 @@ def file_list(path,tree):
     else:
         print("Error: Invalid Path ("+path+")\n")
 
-tree=""
-print(input_params['path']+"\n")
-file_list(input_params['path'],tree)
+def main(path):
+    tree=""
+    print(path+"\n")
+    if path == "/":
+        print("It looks like you're trying to list every file on the system.\n")
+        print("This generates a lot of data so I'm going to exclude less helpful directories\n")
+        print("If you really really want everything including /proc and /sys specify \"//\"\n")
+        files = file.list(path)
+        for f in files:
+            if f['file_name'] not in block_list:
+                file_list("/"+f['file_name'],tree)
+    else:
+        file_list(path,tree)
+
+input_params['path']="/"
+main(input_params['path'])
 print("\n")
 print("\n")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Remove unused output from file tree output.

Output is now:
```
Running `/workspaces/realm/implants/target/debug/golem /workspaces/realm/tavern/tomes/get_net_info/main.eldritch`
Interfaces:

name: lo
ip: 127.0.0.1/8
mac: 00:00:00:00:00:00

name: eth0
ip: 172.17.0.2/16
mac: 02:42:ac:11:00:02

Hostname: 372a47305e3c
```

Instead of:
```
Running `/workspaces/realm/implants/target/debug/golem /workspaces/realm/tavern/tomes/get_net_info/main.eldritch`
OUTPUT: ["Interfaces:\n\n", "name: lo\n", "ip: 127.0.0.1/8\n", "mac: 00:00:00:00:00:00\n", "\n", "name: eth0\n", "ip: 172.17.0.2/16\n", "mac: 02:42:ac:11:00:02\n", "\n", "Hostname: 372a47305e3c", "\n", "\n"]
["Interfaces:\n\n", "name: lo\n", "ip: 127.0.0.1/8\n", "mac: 00:00:00:00:00:00\n", "\n", "name: eth0\n", "ip: 172.17.0.2/16\n", "mac: 02:42:ac:11:00:02\n", "\n", "Hostname: 372a47305e3c", "\n", "\n"]
```


#### Which issue(s) this PR fixes:
Fixes #513 
Fixes #517 

