### PR TITLE
[bug] Fix metrics nil ptr deref on close

### DIFF
--- a/tavern/app.go
+++ b/tavern/app.go
@@ -88,6 +88,9 @@ type Server struct {
 // Close should always be called to clean up a Tavern server.
 func (srv *Server) Close() error {
 	srv.HTTP.Shutdown(context.Background())
+	if srv.MetricsHTTP == nil {
+		return srv.client.Close()
+	}
 	srv.MetricsHTTP.Shutdown(context.Background())
 	return srv.client.Close()
 }


### PR DESCRIPTION
fixes an nil pointer deref that occurs when the metrics server is not created and binding to port fails.
fixes an error that occurs when following the readme as a non root user.
![image](https://github.com/spellshift/realm/assets/22797946/06afa49c-5334-46ab-a1c2-71e264d4c47c)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
