### PR TITLE
[bug] Prevent assets.copy() truncating file when fetch_asset fails

### DIFF
--- a/implants/lib/eldritch/src/crypto/hash_file_impl.rs
+++ b/implants/lib/eldritch/src/crypto/hash_file_impl.rs
@@ -1,13 +1,10 @@
-use std::fs::File;
-use std::io::Read;
-
 use sha1::{Digest, Sha1};
 use sha2::{Sha256, Sha512};
 
 use anyhow::{anyhow, Result};
 
 pub fn hash_file(file: String, algo: String) -> Result<String> {
-    let mut file_data = std::fs::read(file)?;
+    let file_data = std::fs::read(file)?;
     match algo.to_lowercase().as_str() {
         "md5" => Ok(format!("{:02x}", md5::compute(file_data))),
         "sha1" => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

Prevent assets.copy() from truncating the destination file if we fail to fetch the asset.

