### PR TITLE
Make `http.get` and `http.post` ignore TLS validation and be less async

### DIFF
--- a/implants/lib/eldritch/src/http/download_impl.rs
+++ b/implants/lib/eldritch/src/http/download_impl.rs
@@ -12,7 +12,10 @@ async fn handle_download(uri: String, dst: String) -> Result<()> {
 
     // Download as a stream of bytes.
     // there's no checking at all happening here, for anything
-    let mut stream = reqwest::get(uri).await?.bytes_stream();
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+    let mut stream = client.get(uri).send().await?.bytes_stream();
 
     // Write the stream of bytes to the file in chunks
     while let Some(chunk_result) = stream.next().await {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:
Because TLS is never REAL.
