### PR TITLE
[bug] Redirect existing users on new login

### DIFF
--- a/tavern/internal/auth/oauth.go
+++ b/tavern/internal/auth/oauth.go
@@ -151,6 +151,7 @@ func NewOAuthAuthorizationHandler(cfg oauth2.Config, pubKey ed25519.PublicKey, g
 				Expires:  time.Now().AddDate(0, 1, 0),
 			})
 			log.Printf("[INFO] [OAuth] new login for user %q", usr.Name)
+			http.Redirect(w, req, "/", http.StatusFound)
 			return
 		}
 

--- a/tavern/internal/auth/oauth_test.go
+++ b/tavern/internal/auth/oauth_test.go
@@ -152,7 +152,7 @@ func TestNewOAuthAuthorizationHandler(t *testing.T) {
 	req = getOAuthAuthorizationRequest(t, privKey, expectedCode)
 	handler.ServeHTTP(resp, req)
 	result = resp.Result()
-	require.Equal(t, http.StatusOK, result.StatusCode)
+	require.Equal(t, http.StatusFound, result.StatusCode)
 
 	// User assertions
 	assert.Equal(t, 1, graph.User.Query().CountX(context.Background()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

Our `/oauth/authorize` endpoint is setup to create new user accounts (based on oauth state) and redirect users to the application. However, it was not redirecting users with existing user accounts signing in for the first time from a new device. This PR addresses that issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #653 
