### PR TITLE
[bug] Fix fatal on default tome upload

### DIFF
--- a/docs/_docs/user-guide/tomes.md
+++ b/docs/_docs/user-guide/tomes.md
@@ -36,7 +36,7 @@ The `metadata.yml` file specifies key information about a [Tome](/user-guide/ter
 Parameters are defined as a YAML list, but have their own additional properties:
 
 | Name | Description | Required |
-| `name` | Identifier used to access the parameter via the `input_vars` global. | Yes |
+| `name` | Identifier used to access the parameter via the `input_params` global. | Yes |
 | `label` | Display name of the parameter for users of the [Tome](/user-guide/terminology#tome). | Yes |
 | `type` | Type of the parameter in [Eldritch](/user-guide/terminology#eldritch). Current values include: `string`. | Yes |
 | `placeholder` | An example value displayed to users to help explain the parameter's purpose. | Yes |
@@ -53,15 +53,15 @@ paramdefs:
 
 #### Referencing Tome Parameters
 
-If you've defined a parameter for your [Tome](/user-guide/terminology#tome), there's a good chance you'll want to use it. Luckily, [Eldritch](/user-guide/terminology#eldritch) makes this easy for you by providing a global `input_vars` dictionary, which is populated with the parameter values provided to your [Tome](/user-guide/terminology#tome). To access a parameter, simply use the `paramdef` name (defined in `metadata.yml`). For example:
+If you've defined a parameter for your [Tome](/user-guide/terminology#tome), there's a good chance you'll want to use it. Luckily, [Eldritch](/user-guide/terminology#eldritch) makes this easy for you by providing a global `input_params` dictionary, which is populated with the parameter values provided to your [Tome](/user-guide/terminology#tome). To access a parameter, simply use the `paramdef` name (defined in `metadata.yml`). For example:
 
 ```python
 def print_path_param():
-  path = input_vars["path"]
+  path = input_params["path"]
   print(path)
 ```
 
-In the above example, our `metadata.yml` file would specify a value for `paramdefs` with `name: path` set. Then when accessing `input_vars["path"]` the string value provided to the [Tome](/user-guide/terminology#tome) is returned.
+In the above example, our `metadata.yml` file would specify a value for `paramdefs` with `name: path` set. Then when accessing `input_params["path"]` the string value provided to the [Tome](/user-guide/terminology#tome) is returned.
 
 ### Tome Metadata Example
 

--- a/tavern/app.go
+++ b/tavern/app.go
@@ -125,8 +125,7 @@ func NewServer(ctx context.Context, options ...func(*Config)) (*Server, error) {
 
 	// Load Default Tomes
 	if err := tomes.UploadTomes(ctx, client, tomes.FileSystem); err != nil {
-		client.Close()
-		return nil, fmt.Errorf("failed to upload default tomes: %w", err)
+		log.Printf("[ERROR] failed to upload default tomes: %v", err)
 	}
 
 	// Initialize Git Tome Importer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bug 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

When Cloud Run spins up a new container, it will try to upload the default tomes again. This will fail, because the tomes already exist. This change simply logs an error for the default tomes and then continues onward. In the future, it's worth considering removing the default tomes altogether and just providing them via git. 

