### PR TITLE
[bug] Allow GraphQL & CDN to be accessed by unactivated users

### DIFF
--- a/tavern/app.go
+++ b/tavern/app.go
@@ -189,15 +189,26 @@ func NewServer(ctx context.Context, options ...func(*Config)) (*Server, error) {
 			AllowUnauthenticated: true,
 			AllowUnactivated:     true,
 		},
-		"/graphql": tavernhttp.Endpoint{Handler: newGraphQLHandler(client, git)},
+		"/graphql": tavernhttp.Endpoint{
+			Handler:          newGraphQLHandler(client, git),
+			AllowUnactivated: true,
+		},
 		"/c2.C2/": tavernhttp.Endpoint{
 			Handler:              newGRPCHandler(client, grpcShellMux),
 			AllowUnauthenticated: true,
 			AllowUnactivated:     true,
 		},
-		"/cdn/":       tavernhttp.Endpoint{Handler: cdn.NewDownloadHandler(client, "/cdn/")},
-		"/cdn/upload": tavernhttp.Endpoint{Handler: cdn.NewUploadHandler(client)},
-		"/shell/ws":   tavernhttp.Endpoint{Handler: stream.NewShellHandler(client, wsShellMux)},
+		"/cdn/": tavernhttp.Endpoint{
+			Handler:              cdn.NewDownloadHandler(client, "/cdn/"),
+			AllowUnauthenticated: true,
+			AllowUnactivated:     true,
+		},
+		"/cdn/upload": tavernhttp.Endpoint{
+			Handler: cdn.NewUploadHandler(client),
+		},
+		"/shell/ws": tavernhttp.Endpoint{
+			Handler: stream.NewShellHandler(client, wsShellMux),
+		},
 		"/": tavernhttp.Endpoint{
 			Handler:          www.NewHandler(httpLogger),
 			LoginRedirectURI: "/oauth/login",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

Allows `/graphql` and `/cdn/` endpoints to be accessed by unactivated users. In the case of GraphQL, it performs it's own authorization such that unactivated users can run the `me` query and see their own information. For `/cdn/` only file downloads may be unauthenticated and unactivated, since currently Agents do not perform any authentication.

