### PR TITLE
feat(alt-task): Create alternative task view

### DIFF
--- a/tavern/internal/www/src/components/tavern-base-ui/badge/Badge.tsx
+++ b/tavern/internal/www/src/components/tavern-base-ui/badge/Badge.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { FC, useMemo } from "react";
+import { solidBadge } from "./BadgeStyles";
+import { VariantProps } from "tailwind-variants";
+
+// extend the base button attributes
+interface BadgeProps {
+    leftIcon?: React.ReactElement;
+    rightIcon?: React.ReactElement;
+    className?: string,
+    children: any,
+    badgeStyle?: VariantProps<typeof solidBadge>;
+}
+
+const Badge: FC<BadgeProps> = (
+    { children, leftIcon, rightIcon, badgeStyle, className, ...rest }
+) => {
+
+    // determine icon placement
+    const { newIcon: icon, iconPlacement } = useMemo(() => {
+        let newIcon = rightIcon || leftIcon;
+
+        return {
+            newIcon,
+            iconPlacement: rightIcon ? ("right" as const) : ("left" as const),
+        };
+    }, [leftIcon, rightIcon]);
+
+    const renderBadgeVariant = () => {
+        return solidBadge({ ...badgeStyle, className })
+    }
+
+    return (
+        <div
+            className={renderBadgeVariant()}
+            {...rest}
+        >
+            {/** render icon before */}
+            {icon && iconPlacement === "left" ? (
+                <span className={`inline-flex shrink-0 self-center ${children}`}>{icon}</span>
+            ) : null}
+
+            {children}
+
+            {/** render icon after */}
+            {icon && iconPlacement === "right" ? (
+                <span className={`inline-flex shrink-0 self-center  ${children}`}>{icon}</span>
+            ) : null}
+        </div>
+    );
+};
+
+// set default props
+Badge.defaultProps = {
+    leftIcon: undefined,
+    rightIcon: undefined,
+};
+
+export default Badge;

--- a/tavern/internal/www/src/components/tavern-base-ui/badge/BadgeStyles.ts
+++ b/tavern/internal/www/src/components/tavern-base-ui/badge/BadgeStyles.ts
@@ -1,0 +1,46 @@
+import { tv } from 'tailwind-variants';
+
+export const baseBadge = tv({
+  base: 'py-1 px-2 rounded text-xs font-semibold',
+});
+
+// create solid Badge styles
+export const solidBadge = tv({
+  extend: baseBadge,
+  variants: {
+    color: {
+        purple:
+        'btn-primary',
+        red: 'bg-red-600 text-white',
+        gray: 'bg-gray-200 text-gray-900',
+        green: ' bg-green-600 text-white'
+    },
+  },
+});
+
+//create outline Badge styles
+export const outlineBadge = tv({
+  extend: baseBadge,
+  base: 'ring-1',
+  variants: {
+    color: {
+      purple: 'text-purple-800 ring-purple-800',
+      red: 'text-red-600 ring-red-800',
+      gray: 'text-gray-900 ring-gray-500',
+      green: ' bg-green-600 text-white'
+    },
+  },
+});
+
+//create ghost Badge styles
+export const ghostBadge = tv({
+  extend: baseBadge,
+  variants: {
+    color: {
+      purple: 'text-purple-800',
+      red: 'text-red-800',
+      gray: 'text-gray-900',
+      green: ' bg-green-600 text-white'
+    },
+  },
+});

--- a/tavern/internal/www/src/features/task-card/TaskCard.tsx
+++ b/tavern/internal/www/src/features/task-card/TaskCard.tsx
@@ -1,0 +1,39 @@
+import { Task } from "../../utils/consts";
+import { FC } from "react";
+import TaskTimeStamp from "./components/TaskTimeStamp";
+import TaskCreator from "./components/TaskCreator";
+import TaskStatusBadge from "./components/TaskStatusBadge";
+import TaskHostBeacon from "./components/TaskHostBeacon";
+import TaskParameters from "./components/TaskParameters";
+import TaskResults from "./components/TaskResults";
+
+interface TaskCardType {
+    task: Task
+}
+
+const TaskCard: FC<TaskCardType> = (
+    { task }
+) => {
+    return (
+        <div className=" border-2 border-gray-200 px-8 py-5 w-full rounded-lg gap-4 grid grid-cols-1 lg:grid-cols-2">
+            <div className="flex flex-col gap-6 col-span-1">
+                <div className="flex flex-col gap-1">
+                    <div className="flex flex-row gap-2 items-center">
+                        <h3 className="text-lg font-semibold">
+                            {task.quest?.name}
+                        </h3>
+                        <TaskStatusBadge task={task} />
+                    </div>
+                </div>
+                <TaskHostBeacon beaconData={task.beacon} />
+                <TaskTimeStamp {...task} />
+                <TaskParameters quest={task?.quest} />
+                <TaskCreator creatorData={task?.quest?.creator} />
+            </div>
+            <div className="flex flex-col gap-2 col-span-1">
+                <TaskResults output={task?.output} error={task?.error} quest={task?.quest} />
+            </div>
+        </div>
+    );
+};
+export default TaskCard;

--- a/tavern/internal/www/src/features/task-card/components/TaskCreator.tsx
+++ b/tavern/internal/www/src/features/task-card/components/TaskCreator.tsx
@@ -1,0 +1,31 @@
+import { Image } from "@chakra-ui/react";
+import { FC } from "react";
+import { UserType } from "../../../utils/consts";
+
+interface TaskCreatorType {
+    creatorData: UserType | undefined;
+}
+const TaskCreator: FC<TaskCreatorType> = ({
+    creatorData
+}) => {
+
+    if (!creatorData) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-row gap-4">
+            <Image
+                className="mt-1 w-5"
+                borderRadius='full'
+                boxSize='18px'
+                src={creatorData.photoURL}
+                alt={`Profile of ${creatorData.name}`}
+            />
+            <div className="text-gray-600">
+                {creatorData.name}
+            </div>
+        </div>
+    )
+}
+export default TaskCreator;

--- a/tavern/internal/www/src/features/task-card/components/TaskHostBeacon.tsx
+++ b/tavern/internal/www/src/features/task-card/components/TaskHostBeacon.tsx
@@ -1,0 +1,45 @@
+import { BugAntIcon } from "@heroicons/react/24/outline";
+import Badge from "../../../components/tavern-base-ui/badge/Badge";
+import { FC } from "react";
+import { BeaconType } from "../../../utils/consts";
+import { checkIfBeaconOffline } from "../../../utils/utils";
+
+interface TaskHostBeaconType {
+    beaconData: BeaconType
+}
+
+const TaskHostBeacon: FC<TaskHostBeaconType> = ({ beaconData }) => {
+    const {
+        host,
+        principal,
+        name
+    } = beaconData;
+    const beaconOffline = checkIfBeaconOffline(beaconData);
+
+    return (
+        <div className=" flex flex-row gap-4">
+            <BugAntIcon className="h-5 w-5 mt-2" />
+            <div className="flex flex-col gap-1 ">
+                <div className="text-gray-600">
+                    {name}@{host.name}
+                </div>
+                <div className="flex flex-row gap-2 flex-wrap">
+                    {(principal && principal !== "") &&
+                        <Badge badgeStyle={{ color: "gray" }}>{principal}</Badge>
+                    }
+                    {(host?.primaryIP && host?.primaryIP !== "") &&
+                        <Badge badgeStyle={{ color: "gray" }}>{host?.primaryIP}</Badge>
+                    }
+                    {host?.platform &&
+                        <Badge badgeStyle={{ color: "gray" }}>{host?.platform}</Badge>
+                    }
+                    {host?.tags && host?.tags.map((tag: any) => {
+                        return <Badge key={tag.id} badgeStyle={{ color: "gray" }}>{tag.name}</Badge>
+                    })}
+                    {beaconOffline && <Badge badgeStyle={{ color: "gray" }}>Offline</Badge>}
+                </div>
+            </div>
+        </div>
+    );
+};
+export default TaskHostBeacon;

--- a/tavern/internal/www/src/features/task-card/components/TaskParameters.tsx
+++ b/tavern/internal/www/src/features/task-card/components/TaskParameters.tsx
@@ -1,0 +1,42 @@
+import { FC } from "react";
+import { QuestProps, TomeParams } from "../../../utils/consts";
+import { constructTomeParams } from "../../../utils/utils";
+import { WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
+
+interface TaskParametersType {
+    quest?: QuestProps
+}
+const TaskParameters: FC<TaskParametersType> = ({
+    quest
+}) => {
+    const params = constructTomeParams(quest?.parameters, quest?.tome?.paramDefs);
+
+    return (
+        <div className="flex flex-row gap-4">
+            <WrenchScrewdriverIcon className="h-5 w-5 mt-1" />
+            <div className="flex flex-col gap-1 ">
+                <div className="text-gray-600">
+                    Tome parameters
+                </div>
+                {params.map((paramDef: TomeParams) => {
+                    if (paramDef.value) {
+                        return (
+                            <div className="flex flex-row gap-1 text-xs" key={paramDef.name}>
+                                <div className="font-semibold">
+                                    {paramDef.name}:
+                                </div>
+                                <div>
+                                    {paramDef.value}
+                                </div>
+                            </div>
+                        )
+                    }
+                    else {
+                        return null;
+                    }
+                })}
+            </div>
+        </div>
+    );
+};
+export default TaskParameters;

--- a/tavern/internal/www/src/features/task-card/components/TaskResults.tsx
+++ b/tavern/internal/www/src/features/task-card/components/TaskResults.tsx
@@ -1,0 +1,47 @@
+import { FC } from "react";
+import { Task } from "../../../utils/consts";
+import { CodeBlock, tomorrow } from "react-code-blocks";
+import { BookOpenIcon } from "@heroicons/react/24/outline";
+
+interface TaskResultsType extends Pick<Task, 'error' | 'output' | 'quest'> { };
+
+const TaskResults: FC<TaskResultsType> = ({
+    error,
+    output,
+    quest
+}) => {
+    return (
+        <div className="flex flex-row gap-4">
+            <BookOpenIcon className="h-5 w-5 mt-1" />
+            <div className="flex flex-col gap-1 ">
+                <div className="text-gray-600">
+                    Tome: {quest?.tome?.name}
+                </div>
+                <div className="flex flex-col gap-2 text-sm max-h-80 overflow-y-scroll">
+                    {error ? (
+                        <CodeBlock
+                            className="-ml-2"
+                            text={error}
+                            language={""}
+                            showLineNumbers={false}
+                            theme={tomorrow}
+                            codeBlock
+                        />
+                    ) : output && output?.length > 0 ? (
+                        <CodeBlock
+                            className="-ml-2"
+                            text={output}
+                            language={""}
+                            showLineNumbers={false}
+                            theme={tomorrow}
+                            codeBlock
+                        />
+                    ) : (
+                        <div className="mt-2 text-gray-600">No output available</div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+export default TaskResults;

--- a/tavern/internal/www/src/features/task-card/components/TaskStatusBadge.tsx
+++ b/tavern/internal/www/src/features/task-card/components/TaskStatusBadge.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import Badge from "../../../components/tavern-base-ui/badge/Badge";
+
+type Props = {
+    task: any;
+}
+const TaskStatusBadge = (props: Props) => {
+    const { task } = props;
+
+    if (task.error.length > 0) return <Badge badgeStyle={{ color: 'red' }} >Error</Badge>;
+    else if (task.execFinishedAt) return <Badge badgeStyle={{ color: 'green' }} >Finished</Badge>;
+    else if (task.execStartedAt) return <Badge badgeStyle={{ color: 'gray' }} >In progress</Badge>;
+    else return <Badge badgeStyle={{ color: 'gray' }} >Queued</Badge>;
+}
+export default TaskStatusBadge;

--- a/tavern/internal/www/src/features/task-card/components/TaskTimeStamp.tsx
+++ b/tavern/internal/www/src/features/task-card/components/TaskTimeStamp.tsx
@@ -1,0 +1,28 @@
+import { FC, ReactElement } from "react";
+import { Task } from "../../../utils/consts";
+import { ClockIcon } from "@heroicons/react/24/outline";
+
+interface TaskTimeStampType extends Pick<Task, 'createdAt' | 'execStartedAt' | 'execFinishedAt'> { };
+
+const TaskTimeStamp: FC<TaskTimeStampType> = ({
+    createdAt,
+    execStartedAt,
+    execFinishedAt
+}): ReactElement => {
+    const createdTime = new Date(createdAt || "");
+    const startTime = new Date(execStartedAt || "");
+    const finishTime = new Date(execFinishedAt || "");
+
+    return (
+        <div className="flex flex-row gap-4">
+            <ClockIcon className="h-5 w-5 mt-1" />
+            <div className="flex flex-col gap-1 ">
+                <div className="text-gray-600">Status</div>
+                {createdAt && <span className="text-xs">{`Created at ${createdTime.toLocaleTimeString()} on ${createdTime.toDateString()}`}</span>}
+                {execStartedAt && <span className="text-xs">{`Started at ${startTime.toLocaleTimeString()} on ${startTime.toDateString()}`}</span>}
+                {execFinishedAt && <span className="text-xs">{`Finished at ${finishTime.toLocaleTimeString()} on ${finishTime.toDateString()}`}</span>}
+            </div>
+        </div>
+    );
+}
+export default TaskTimeStamp;

--- a/tavern/internal/www/src/pages/host-details/components/HostContent.tsx
+++ b/tavern/internal/www/src/pages/host-details/components/HostContent.tsx
@@ -33,7 +33,7 @@ const HostContent = () => {
 
     return (
         <>
-            <div className="border-b border-gray-200 pb-5 sm:flex sm:items-center sm:justify-between">
+            <div className="pb-5 sm:flex sm:items-center sm:justify-between">
                 <EditableHostHeader hostId={hostId} loading={loading} error={error} hostData={host} />
             </div>
             <div className="my-2">

--- a/tavern/internal/www/src/pages/host-details/components/HostTasks.tsx
+++ b/tavern/internal/www/src/pages/host-details/components/HostTasks.tsx
@@ -1,15 +1,14 @@
-import { useState } from "react";
 import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel, Box } from "@chakra-ui/react";
 import { Link, useParams } from "react-router-dom";
 
-import { TaskOutput } from "../../../features/task-output";
-import TaskTable from "../../../components/TaskTable";
 import { EmptyState, EmptyStateType } from "../../../components/tavern-base-ui/EmptyState";
 import TablePagination from "../../../components/tavern-base-ui/TablePagination";
 import { DEFAULT_QUERY_TYPE, TableRowLimit } from "../../../utils/enums";
 import FreeTextSearch from "../../../components/tavern-base-ui/DebouncedFreeTextSearch";
 import { useTasks } from "../../../hooks/useTasks";
 import Button from "../../../components/tavern-base-ui/button/Button";
+import TaskCard from "../../../features/task-card/TaskCard";
+import { Task } from "../../../utils/consts";
 
 const HostTasks = () => {
     const { hostId } = useParams();
@@ -23,15 +22,6 @@ const HostTasks = () => {
         updateTaskList
     } = useTasks(DEFAULT_QUERY_TYPE.hostIDQuery, hostId);
 
-    const [isOpen, setOpen] = useState(false);
-    const [selectedTask, setSelectedTask] = useState<any | null>(null);
-
-    const handleClick = (e: any) => {
-        const selectedTaskData = e?.original?.node;
-        setSelectedTask(selectedTaskData);
-        setOpen((state) => !state);
-    }
-
     return (
         <Accordion allowToggle className='w-full' defaultIndex={[0]}>
             <AccordionItem>
@@ -43,7 +33,7 @@ const HostTasks = () => {
                 </AccordionButton>
                 <AccordionPanel>
                     <div className="flex flex-col gap-2">
-                        <div className="px-6 pt-2 ">
+                        <div className="pt-2 ">
                             <FreeTextSearch setSearch={setSearch} />
                         </div>
                         {taskLoading ? (
@@ -54,7 +44,13 @@ const HostTasks = () => {
                             <div>
                                 {taskData?.tasks?.edges.length > 0 ? (
                                     <>
-                                        <TaskTable tasks={taskData?.tasks?.edges} onToggle={handleClick} />
+                                        <div className=" w-full flex flex-col gap-2 my-4">
+                                            {taskData.tasks.edges.map((task: { node: Task }) => {
+                                                return (
+                                                    <TaskCard key={task.node.id} task={task.node} />
+                                                )
+                                            })}
+                                        </div>
                                         <TablePagination totalCount={taskData?.tasks?.totalCount} pageInfo={taskData?.tasks?.pageInfo} refetchTable={updateTaskList} page={page} setPage={setPage} rowLimit={TableRowLimit.TaskRowLimit} />
                                     </>
                                 )
@@ -72,7 +68,6 @@ const HostTasks = () => {
                             </div>
                         )}
                     </div>
-                    {isOpen && <TaskOutput isOpen={isOpen} setOpen={setOpen} selectedTask={selectedTask} />}
                 </AccordionPanel>
             </AccordionItem>
         </Accordion>

--- a/tavern/internal/www/src/pages/host-list/HostList.tsx
+++ b/tavern/internal/www/src/pages/host-list/HostList.tsx
@@ -28,7 +28,7 @@ const HostList = () => {
                 ) : error ? (
                     <EmptyState type={EmptyStateType.error} label="Error hosts..." />
                 ) : (filteredHosts.length > 0) ? (
-                    <div className="py-4 bg-white rounded-lg shadow-lg mt-2 flex flex-col gap-1 w-full">
+                    <div className="mt-2 flex flex-col gap-1 w-full">
                         <HostTable data={filteredHosts} />
                     </div>
                 ) : (hosts.length > 0) ? (

--- a/tavern/internal/www/src/pages/host-list/components/HostFilter.tsx
+++ b/tavern/internal/www/src/pages/host-list/components/HostFilter.tsx
@@ -20,7 +20,7 @@ const HostFilter = (
     return (
         <div>
             {(!isLoading && !error && data) && (
-                <div className="p-4 bg-white rounded-lg shadow-lg mt-2">
+                <div className="mt-2">
                     <BeaconFilterBar beacons={data?.beacons || []} groups={data?.groupTags || []} services={data?.serviceTags || []} hosts={data?.hosts || []} setFiltersSelected={setFiltersSelected} filtersSelected={typeFilters} />
                 </div>
             )}

--- a/tavern/internal/www/src/pages/quest-list/Quests.tsx
+++ b/tavern/internal/www/src/pages/quest-list/Quests.tsx
@@ -25,7 +25,7 @@ const Quests = () => {
     return (
         <PageWrapper currNavItem={PageNavItem.quests}>
             <QuestHeader />
-            <div className="p-4 bg-white rounded-lg shadow-lg mt-2">
+            <div className="bg-white  mt-2">
                 <FilterBar setSearch={setSearch} searchPlaceholder="Search by quest or tome name" filtersSelected={filtersSelected} setFiltersSelected={setFiltersSelected} />
             </div>
             {(loading) ?
@@ -33,7 +33,7 @@ const Quests = () => {
                 : error ?
                     <EmptyState type={EmptyStateType.error} label="Error loading quests" />
                     : data?.quests?.edges.length > 0 ?
-                        <div className="py-4 bg-white rounded-lg shadow-lg mt-2 flex flex-col gap-1 w-full">
+                        <div className="py-4 mt-2 flex flex-col gap-1 w-full">
                             <QuestTable quests={data?.quests?.edges} filtersSelected={filtersSelected} />
                             <TablePagination totalCount={data?.quests?.totalCount} pageInfo={data?.quests?.pageInfo} refetchTable={updateQuestList} page={page} setPage={setPage} rowLimit={TableRowLimit.QuestRowLimit} />
                         </div>

--- a/tavern/internal/www/src/pages/tasks/Tasks.tsx
+++ b/tavern/internal/www/src/pages/tasks/Tasks.tsx
@@ -1,8 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { PageWrapper } from "../../components/page-wrapper";
-import { TaskOutput } from "../../features/task-output";
-import TaskTable from "../../components/TaskTable";
 import { EmptyState, EmptyStateType } from "../../components/tavern-base-ui/EmptyState";
 import TablePagination from "../../components/tavern-base-ui/TablePagination";
 import { DEFAULT_QUERY_TYPE, PageNavItem, TableRowLimit } from "../../utils/enums";
@@ -12,6 +10,7 @@ import { Task } from "../../utils/consts";
 import { EditablePageHeader } from "./EditablePageHeader";
 import { useQuests } from "../../hooks/useQuests";
 import Button from "../../components/tavern-base-ui/button/Button";
+import TaskCard from "../../features/task-card/TaskCard";
 
 const Tasks = () => {
     const { questId } = useParams();
@@ -35,15 +34,6 @@ const Tasks = () => {
         setFiltersSelected: setQuestFiltersSelected
     } = useQuests(false, questId);
 
-    const [isOpen, setOpen] = useState(false);
-    const [selectedTask, setSelectedTask] = useState<Task | null>(null);
-
-    const handleClick = (e: any) => {
-        const selectedTaskData = e?.original?.node;
-        setSelectedTask(selectedTaskData);
-        setOpen((state) => !state);
-    }
-
     const handleFilterSelected = (filtersSelected: Array<any>) => {
         setFiltersSelected(filtersSelected);
         setQuestFiltersSelected(filtersSelected);
@@ -54,7 +44,7 @@ const Tasks = () => {
             <div className="border-b border-gray-200 pb-5 sm:flex sm:items-center sm:justify-between">
                 <EditablePageHeader questId={questId} data={questData} loading={questLoading} error={questError} />
             </div>
-            <div className="p-4 bg-white rounded-lg shadow-lg mt-2">
+            <div className="bg-white rounded-lg mt-2">
                 <FilterBar setSearch={setSearch} filtersSelected={filtersSelected} setFiltersSelected={handleFilterSelected} />
             </div>
             {loading ? (
@@ -64,8 +54,14 @@ const Tasks = () => {
             ) : (
                 <div>
                     {data?.tasks?.edges.length > 0 ? (
-                        <div className="py-4 bg-white rounded-lg shadow-lg mt-2 flex flex-col gap-1">
-                            <TaskTable tasks={data?.tasks?.edges} onToggle={handleClick} />
+                        <div className="">
+                            <div className=" w-full flex flex-col gap-2 my-4">
+                                {data.tasks.edges.map((task: { node: Task }) => {
+                                    return (
+                                        <TaskCard key={task.node.id} task={task.node} />
+                                    )
+                                })}
+                            </div>
                             <TablePagination totalCount={data?.tasks?.totalCount} pageInfo={data?.tasks?.pageInfo} refetchTable={updateTaskList} page={page} setPage={setPage} rowLimit={TableRowLimit.TaskRowLimit} />
                         </div>
                     ) : (
@@ -82,7 +78,6 @@ const Tasks = () => {
                     )}
                 </div>
             )}
-            {isOpen && <TaskOutput isOpen={isOpen} setOpen={setOpen} selectedTask={selectedTask} />}
         </PageWrapper>
     );
 };

--- a/tavern/internal/www/src/style.css
+++ b/tavern/internal/www/src/style.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+code {
+  padding: 0px;
+}
+
 .option-container {
   width: 100%;
   background-color: #EDF2F7;

--- a/tavern/internal/www/src/utils/queries.ts
+++ b/tavern/internal/www/src/utils/queries.ts
@@ -258,6 +258,7 @@ export const GET_TASK_QUERY = gql`
                         createdAt
                         claimedAt
                         error
+                        output
                         quest{
                             id
                             name


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

- New task view that shows output data and is in card format instead of table format
- We want to reduce the need to 'click in' to view task data.

#### Screenshots
<img width="1725" alt="Screenshot 2024-04-11 at 10 49 02 PM" src="https://github.com/spellshift/realm/assets/32434695/c95e5ee1-a7dc-465b-8516-aa727d3cae2a">


