### PR TITLE
Use world writeable paths

### DIFF
--- a/implants/imix/src/config.rs
+++ b/implants/imix/src/config.rs
@@ -215,8 +215,14 @@ fn get_host_id_path() -> String {
     #[cfg(target_os = "windows")]
     return String::from("C:\\ProgramData\\system-id");
 
-    #[cfg(not(target_os = "windows"))]
-    return String::from("/etc/system-id");
+    #[cfg(target_os = "linux")]
+    return String::from("/var/run/lock/system-id");
+
+    #[cfg(target_os = "macos")]
+    return String::from("/Users/Shared/system-id");
+
+    #[cfg(target_os = "freebsd")]
+    return String::from("/var/run/systemd-id");
 }
 
 /*


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`/etc` was only writeable by root sogonna swap over to allow non root users to still get host uniqueness.
