### PR TITLE
Change anyhow import to fix FreeBSD

### DIFF
--- a/implants/lib/eldritch/src/process/netstat_impl.rs
+++ b/implants/lib/eldritch/src/process/netstat_impl.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use starlark::values::{dict::Dict, Heap};
 
 #[cfg(target_os = "freebsd")]
@@ -68,7 +68,7 @@ mod tests {
         if bytes_copied > 1 {
             Ok(())
         } else {
-            Err(anyhow::anyhow!("Failed to copy any bytes"))
+            Err(anyhow!("Failed to copy any bytes"))
         }
     }
 
@@ -115,6 +115,6 @@ mod tests {
                 }
             }
         }
-        Err(anyhow::anyhow!("Failed to find socket"))
+        Err(anyhow!("Failed to find socket"))
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Order of imports with `implants/lib/eldritch/src/process/netstat_impl.rs` caused compilation to fail on FreeBSD. By importing the anyhow macro at the top, this solves this error without changing any other code.

#### Which issue(s) this PR fixes:
:shipit: 
