### PR TITLE
[Tavern] Create Unique Pubsub Subscriptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.117.0 // indirect
 	cloud.google.com/go/auth v0.13.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.6 // indirect
 	cloud.google.com/go/iam v1.3.1 // indirect

--- a/tavern/app.go
+++ b/tavern/app.go
@@ -31,7 +31,6 @@ import (
 	"realm.pub/tavern/internal/graphql"
 	tavernhttp "realm.pub/tavern/internal/http"
 	"realm.pub/tavern/internal/http/stream"
-	"realm.pub/tavern/internal/namegen"
 	"realm.pub/tavern/internal/www"
 	"realm.pub/tavern/tomes"
 )
@@ -358,10 +357,9 @@ func registerProfiler(router tavernhttp.RouteMap) {
 }
 
 func configureLogging() {
-	// Generate new instance ID as prefix (helps in deployments with multiple tavern instances)
+	// Use instance ID as prefix (helps in deployments with multiple tavern instances)
 	var (
-		instanceID = namegen.NewSimple()
-		logger     *slog.Logger
+		logger *slog.Logger
 	)
 
 	// Setup Default Logger
@@ -370,14 +368,14 @@ func configureLogging() {
 		logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
 		})).
-			With("tavern_id", instanceID)
+			With("tavern_id", GlobalInstanceID)
 	} else {
 		// Debug Logging
 		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 			Level:     slog.LevelDebug,
 			AddSource: true,
 		})).
-			With("tavern_id", instanceID)
+			With("tavern_id", GlobalInstanceID)
 	}
 
 	slog.SetDefault(logger)

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -183,8 +183,8 @@ func (cfg *Config) NewShellMuxes(ctx context.Context) (wsMux *stream.Mux, grpcMu
 			}
 			return name
 		}
-		subShellInput = fmt.Sprintf("gcpubsub://", createGCPSubscription(ctx, EnvPubSubSubscriptionShellInput))
-		subShellOutput = fmt.Sprintf("gcpubsub://", createGCPSubscription(ctx, EnvPubSubSubscriptionShellOutput))
+		subShellInput = fmt.Sprintf("gcpubsub://%s", createGCPSubscription(ctx, EnvPubSubSubscriptionShellInput))
+		subShellOutput = fmt.Sprintf("gcpubsub://%s", createGCPSubscription(ctx, EnvPubSubSubscriptionShellOutput))
 	}
 
 	subOutput, err := pubsub.OpenSubscription(ctx, subShellOutput)

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -192,6 +192,8 @@ func (cfg *Config) NewShellMuxes(ctx context.Context) (wsMux *stream.Mux, grpcMu
 
 		shellInputTopic := client.Topic(strings.TrimPrefix(EnvPubSubTopicShellInput.String(), "gcppubsub://"))
 		shellOutputTopic := client.Topic(strings.TrimPrefix(EnvPubSubTopicShellInput.String(), "gcppubsub://"))
+
+		// Overwrite env var specification with newly created GCP PubSub Subscriptions
 		subShellInput = fmt.Sprintf("gcpubsub://%s", createGCPSubscription(ctx, EnvPubSubSubscriptionShellInput, shellInputTopic))
 		subShellOutput = fmt.Sprintf("gcpubsub://%s", createGCPSubscription(ctx, EnvPubSubSubscriptionShellOutput, shellOutputTopic))
 	}

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -182,7 +182,7 @@ func (cfg *Config) NewShellMuxes(ctx context.Context) (wsMux *stream.Mux, grpcMu
 			}
 			exists, err := sub.Exists(ctx)
 			if err != nil {
-				panic(fmt.Errorf("failed to check if gcppubsub subscription was succesfully created: %w", err))
+				panic(fmt.Errorf("failed to check if gcppubsub subscription was successfully created: %w", err))
 			}
 			if !exists {
 				panic(fmt.Errorf("failed to create gcppubsub subscription, it does not exist! name=%q", name))


### PR DESCRIPTION
…tavern instance

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Updates Tavern to connect and create a new unique pubsub subscription for each instance of Tavern. The subscriptions are currently configured to expire after 1 day of inactivity. This is necessary because GCP Pubsub load-balances messages across all subscribers that share the same subscription, meaning for reverse shells when multiple instances of tavern are running they each only get a fragment of the messages (and therefore the shell works very poorly with more than one running instance). Read more here: https://cloud.google.com/pubsub/docs/pubsub-basics#choose_a_publish_and_subscribe_pattern


