### PR TITLE
Windows backrgound exec

### DIFF
--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -789,7 +789,8 @@ If your dll_bytes array contains a value greater than u8::MAX it will cause the 
 `sys.exec(path: str, args: List<str>, disown: Optional<bool>) -> Dict`
 
 The <b>sys.exec</b> method executes a program specified with `path` and passes the `args` list.
-Disown will run the process in the background disowned from the agent. This is done through double forking and only works on *nix systems.
+On *nix systems disown will run the process in the background disowned from the agent. This is done through double forking.
+On Windows systems disown will run the process with detached stdin and stdout such that it won't block the tomes execution.
 
 ```python
 sys.exec("/bin/bash",["-c", "whoami"])

--- a/implants/lib/eldritch/src/sys/exec_impl.rs
+++ b/implants/lib/eldritch/src/sys/exec_impl.rs
@@ -48,10 +48,19 @@ fn handle_exec(path: String, args: Vec<String>, disown: Option<bool>) -> Result<
         Ok(res)
     } else {
         #[cfg(target_os = "windows")]
-        return Err(anyhow::anyhow!(
-            "Windows is not supported for disowned processes."
-        ));
+        {
+            let _ = Command::new(path)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .args(args)
+                .spawn();
 
+            Ok(CommandOutput {
+                stdout: "".to_string(),
+                stderr: "".to_string(),
+                status: 0,
+            })
+        }
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
         match unsafe { fork()? } {
             ForkResult::Parent { child } => {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Allow `sys.exec` to run windows commands non-blocking by detaching stdout and stderr

#### Which issue(s) this PR fixes:
Fixes #
