### PR TITLE
Add External IP Field to Hosts

### DIFF
--- a/tavern/internal/c2/api_claim_tasks.go
+++ b/tavern/internal/c2/api_claim_tasks.go
@@ -43,8 +43,6 @@ func getRemoteIP(ctx context.Context) string {
 		return "unknown"
 	}
 
-	fmt.Println("Peer:", p)
-
 	host, _, err := net.SplitHostPort(p.Addr.String())
 	if err != nil {
 		return "unknown"

--- a/tavern/internal/c2/api_claim_tasks.go
+++ b/tavern/internal/c2/api_claim_tasks.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"realm.pub/tavern/internal/c2/c2pb"
 	"realm.pub/tavern/internal/c2/epb"
@@ -34,8 +37,39 @@ func init() {
 	prometheus.MustRegister(metricHostCallbacksTotal)
 }
 
+func getRemoteIP(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return "unknown"
+	}
+
+	fmt.Println("Peer:", p)
+
+	host, _, err := net.SplitHostPort(p.Addr.String())
+	if err != nil {
+		return "unknown"
+	}
+
+	return host
+}
+
+func getClientIP(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if forwardedFor, exists := md["x-forwarded-for"]; exists && len(forwardedFor) > 0 {
+			// X-Forwarded-For is a comma-separated list, the first IP is the original client
+			clientIP := strings.Split(forwardedFor[0], ",")[0]
+			return strings.TrimSpace(clientIP)
+		}
+	}
+
+	// Fallback to peer address
+	return getRemoteIP(ctx)
+}
+
 func (srv *Server) ClaimTasks(ctx context.Context, req *c2pb.ClaimTasksRequest) (*c2pb.ClaimTasksResponse, error) {
 	now := time.Now()
+	clientIP := getClientIP(ctx)
 
 	// Validate input
 	if req.Beacon == nil {
@@ -66,6 +100,7 @@ func (srv *Server) ClaimTasks(ctx context.Context, req *c2pb.ClaimTasksRequest) 
 		SetName(req.Beacon.Host.Name).
 		SetPlatform(req.Beacon.Host.Platform).
 		SetPrimaryIP(req.Beacon.Host.PrimaryIp).
+		SetExternalIP(clientIP).
 		SetLastSeenAt(now).
 		OnConflict().
 		UpdateNewValues().

--- a/tavern/internal/ent/gql_collection.go
+++ b/tavern/internal/ent/gql_collection.go
@@ -495,6 +495,11 @@ func (h *HostQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 				selectedFields = append(selectedFields, host.FieldPrimaryIP)
 				fieldSeen[host.FieldPrimaryIP] = struct{}{}
 			}
+		case "externalIP":
+			if _, ok := fieldSeen[host.FieldExternalIP]; !ok {
+				selectedFields = append(selectedFields, host.FieldExternalIP)
+				fieldSeen[host.FieldExternalIP] = struct{}{}
+			}
 		case "platform":
 			if _, ok := fieldSeen[host.FieldPlatform]; !ok {
 				selectedFields = append(selectedFields, host.FieldPlatform)

--- a/tavern/internal/ent/gql_where_input.go
+++ b/tavern/internal/ent/gql_where_input.go
@@ -1041,6 +1041,23 @@ type HostWhereInput struct {
 	PrimaryIPEqualFold    *string  `json:"primaryIPEqualFold,omitempty"`
 	PrimaryIPContainsFold *string  `json:"primaryIPContainsFold,omitempty"`
 
+	// "external_ip" field predicates.
+	ExternalIP             *string  `json:"externalIP,omitempty"`
+	ExternalIPNEQ          *string  `json:"externalIPNEQ,omitempty"`
+	ExternalIPIn           []string `json:"externalIPIn,omitempty"`
+	ExternalIPNotIn        []string `json:"externalIPNotIn,omitempty"`
+	ExternalIPGT           *string  `json:"externalIPGT,omitempty"`
+	ExternalIPGTE          *string  `json:"externalIPGTE,omitempty"`
+	ExternalIPLT           *string  `json:"externalIPLT,omitempty"`
+	ExternalIPLTE          *string  `json:"externalIPLTE,omitempty"`
+	ExternalIPContains     *string  `json:"externalIPContains,omitempty"`
+	ExternalIPHasPrefix    *string  `json:"externalIPHasPrefix,omitempty"`
+	ExternalIPHasSuffix    *string  `json:"externalIPHasSuffix,omitempty"`
+	ExternalIPIsNil        bool     `json:"externalIPIsNil,omitempty"`
+	ExternalIPNotNil       bool     `json:"externalIPNotNil,omitempty"`
+	ExternalIPEqualFold    *string  `json:"externalIPEqualFold,omitempty"`
+	ExternalIPContainsFold *string  `json:"externalIPContainsFold,omitempty"`
+
 	// "platform" field predicates.
 	Platform      *c2pb.Host_Platform  `json:"platform,omitempty"`
 	PlatformNEQ   *c2pb.Host_Platform  `json:"platformNEQ,omitempty"`
@@ -1351,6 +1368,51 @@ func (i *HostWhereInput) P() (predicate.Host, error) {
 	}
 	if i.PrimaryIPContainsFold != nil {
 		predicates = append(predicates, host.PrimaryIPContainsFold(*i.PrimaryIPContainsFold))
+	}
+	if i.ExternalIP != nil {
+		predicates = append(predicates, host.ExternalIPEQ(*i.ExternalIP))
+	}
+	if i.ExternalIPNEQ != nil {
+		predicates = append(predicates, host.ExternalIPNEQ(*i.ExternalIPNEQ))
+	}
+	if len(i.ExternalIPIn) > 0 {
+		predicates = append(predicates, host.ExternalIPIn(i.ExternalIPIn...))
+	}
+	if len(i.ExternalIPNotIn) > 0 {
+		predicates = append(predicates, host.ExternalIPNotIn(i.ExternalIPNotIn...))
+	}
+	if i.ExternalIPGT != nil {
+		predicates = append(predicates, host.ExternalIPGT(*i.ExternalIPGT))
+	}
+	if i.ExternalIPGTE != nil {
+		predicates = append(predicates, host.ExternalIPGTE(*i.ExternalIPGTE))
+	}
+	if i.ExternalIPLT != nil {
+		predicates = append(predicates, host.ExternalIPLT(*i.ExternalIPLT))
+	}
+	if i.ExternalIPLTE != nil {
+		predicates = append(predicates, host.ExternalIPLTE(*i.ExternalIPLTE))
+	}
+	if i.ExternalIPContains != nil {
+		predicates = append(predicates, host.ExternalIPContains(*i.ExternalIPContains))
+	}
+	if i.ExternalIPHasPrefix != nil {
+		predicates = append(predicates, host.ExternalIPHasPrefix(*i.ExternalIPHasPrefix))
+	}
+	if i.ExternalIPHasSuffix != nil {
+		predicates = append(predicates, host.ExternalIPHasSuffix(*i.ExternalIPHasSuffix))
+	}
+	if i.ExternalIPIsNil {
+		predicates = append(predicates, host.ExternalIPIsNil())
+	}
+	if i.ExternalIPNotNil {
+		predicates = append(predicates, host.ExternalIPNotNil())
+	}
+	if i.ExternalIPEqualFold != nil {
+		predicates = append(predicates, host.ExternalIPEqualFold(*i.ExternalIPEqualFold))
+	}
+	if i.ExternalIPContainsFold != nil {
+		predicates = append(predicates, host.ExternalIPContainsFold(*i.ExternalIPContainsFold))
 	}
 	if i.Platform != nil {
 		predicates = append(predicates, host.PlatformEQ(*i.Platform))

--- a/tavern/internal/ent/host/host.go
+++ b/tavern/internal/ent/host/host.go
@@ -27,6 +27,8 @@ const (
 	FieldName = "name"
 	// FieldPrimaryIP holds the string denoting the primary_ip field in the database.
 	FieldPrimaryIP = "primary_ip"
+	// FieldExternalIP holds the string denoting the external_ip field in the database.
+	FieldExternalIP = "external_ip"
 	// FieldPlatform holds the string denoting the platform field in the database.
 	FieldPlatform = "platform"
 	// FieldLastSeenAt holds the string denoting the last_seen_at field in the database.
@@ -86,6 +88,7 @@ var Columns = []string{
 	FieldIdentifier,
 	FieldName,
 	FieldPrimaryIP,
+	FieldExternalIP,
 	FieldPlatform,
 	FieldLastSeenAt,
 }
@@ -160,6 +163,11 @@ func ByName(opts ...sql.OrderTermOption) OrderOption {
 // ByPrimaryIP orders the results by the primary_ip field.
 func ByPrimaryIP(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPrimaryIP, opts...).ToFunc()
+}
+
+// ByExternalIP orders the results by the external_ip field.
+func ByExternalIP(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExternalIP, opts...).ToFunc()
 }
 
 // ByPlatform orders the results by the platform field.

--- a/tavern/internal/ent/host/where.go
+++ b/tavern/internal/ent/host/where.go
@@ -81,6 +81,11 @@ func PrimaryIP(v string) predicate.Host {
 	return predicate.Host(sql.FieldEQ(FieldPrimaryIP, v))
 }
 
+// ExternalIP applies equality check predicate on the "external_ip" field. It's identical to ExternalIPEQ.
+func ExternalIP(v string) predicate.Host {
+	return predicate.Host(sql.FieldEQ(FieldExternalIP, v))
+}
+
 // LastSeenAt applies equality check predicate on the "last_seen_at" field. It's identical to LastSeenAtEQ.
 func LastSeenAt(v time.Time) predicate.Host {
 	return predicate.Host(sql.FieldEQ(FieldLastSeenAt, v))
@@ -379,6 +384,81 @@ func PrimaryIPEqualFold(v string) predicate.Host {
 // PrimaryIPContainsFold applies the ContainsFold predicate on the "primary_ip" field.
 func PrimaryIPContainsFold(v string) predicate.Host {
 	return predicate.Host(sql.FieldContainsFold(FieldPrimaryIP, v))
+}
+
+// ExternalIPEQ applies the EQ predicate on the "external_ip" field.
+func ExternalIPEQ(v string) predicate.Host {
+	return predicate.Host(sql.FieldEQ(FieldExternalIP, v))
+}
+
+// ExternalIPNEQ applies the NEQ predicate on the "external_ip" field.
+func ExternalIPNEQ(v string) predicate.Host {
+	return predicate.Host(sql.FieldNEQ(FieldExternalIP, v))
+}
+
+// ExternalIPIn applies the In predicate on the "external_ip" field.
+func ExternalIPIn(vs ...string) predicate.Host {
+	return predicate.Host(sql.FieldIn(FieldExternalIP, vs...))
+}
+
+// ExternalIPNotIn applies the NotIn predicate on the "external_ip" field.
+func ExternalIPNotIn(vs ...string) predicate.Host {
+	return predicate.Host(sql.FieldNotIn(FieldExternalIP, vs...))
+}
+
+// ExternalIPGT applies the GT predicate on the "external_ip" field.
+func ExternalIPGT(v string) predicate.Host {
+	return predicate.Host(sql.FieldGT(FieldExternalIP, v))
+}
+
+// ExternalIPGTE applies the GTE predicate on the "external_ip" field.
+func ExternalIPGTE(v string) predicate.Host {
+	return predicate.Host(sql.FieldGTE(FieldExternalIP, v))
+}
+
+// ExternalIPLT applies the LT predicate on the "external_ip" field.
+func ExternalIPLT(v string) predicate.Host {
+	return predicate.Host(sql.FieldLT(FieldExternalIP, v))
+}
+
+// ExternalIPLTE applies the LTE predicate on the "external_ip" field.
+func ExternalIPLTE(v string) predicate.Host {
+	return predicate.Host(sql.FieldLTE(FieldExternalIP, v))
+}
+
+// ExternalIPContains applies the Contains predicate on the "external_ip" field.
+func ExternalIPContains(v string) predicate.Host {
+	return predicate.Host(sql.FieldContains(FieldExternalIP, v))
+}
+
+// ExternalIPHasPrefix applies the HasPrefix predicate on the "external_ip" field.
+func ExternalIPHasPrefix(v string) predicate.Host {
+	return predicate.Host(sql.FieldHasPrefix(FieldExternalIP, v))
+}
+
+// ExternalIPHasSuffix applies the HasSuffix predicate on the "external_ip" field.
+func ExternalIPHasSuffix(v string) predicate.Host {
+	return predicate.Host(sql.FieldHasSuffix(FieldExternalIP, v))
+}
+
+// ExternalIPIsNil applies the IsNil predicate on the "external_ip" field.
+func ExternalIPIsNil() predicate.Host {
+	return predicate.Host(sql.FieldIsNull(FieldExternalIP))
+}
+
+// ExternalIPNotNil applies the NotNil predicate on the "external_ip" field.
+func ExternalIPNotNil() predicate.Host {
+	return predicate.Host(sql.FieldNotNull(FieldExternalIP))
+}
+
+// ExternalIPEqualFold applies the EqualFold predicate on the "external_ip" field.
+func ExternalIPEqualFold(v string) predicate.Host {
+	return predicate.Host(sql.FieldEqualFold(FieldExternalIP, v))
+}
+
+// ExternalIPContainsFold applies the ContainsFold predicate on the "external_ip" field.
+func ExternalIPContainsFold(v string) predicate.Host {
+	return predicate.Host(sql.FieldContainsFold(FieldExternalIP, v))
 }
 
 // PlatformEQ applies the EQ predicate on the "platform" field.

--- a/tavern/internal/ent/host_create.go
+++ b/tavern/internal/ent/host_create.go
@@ -90,6 +90,20 @@ func (hc *HostCreate) SetNillablePrimaryIP(s *string) *HostCreate {
 	return hc
 }
 
+// SetExternalIP sets the "external_ip" field.
+func (hc *HostCreate) SetExternalIP(s string) *HostCreate {
+	hc.mutation.SetExternalIP(s)
+	return hc
+}
+
+// SetNillableExternalIP sets the "external_ip" field if the given value is not nil.
+func (hc *HostCreate) SetNillableExternalIP(s *string) *HostCreate {
+	if s != nil {
+		hc.SetExternalIP(*s)
+	}
+	return hc
+}
+
 // SetPlatform sets the "platform" field.
 func (hc *HostCreate) SetPlatform(cp c2pb.Host_Platform) *HostCreate {
 	hc.mutation.SetPlatform(cp)
@@ -306,6 +320,10 @@ func (hc *HostCreate) createSpec() (*Host, *sqlgraph.CreateSpec) {
 		_spec.SetField(host.FieldPrimaryIP, field.TypeString, value)
 		_node.PrimaryIP = value
 	}
+	if value, ok := hc.mutation.ExternalIP(); ok {
+		_spec.SetField(host.FieldExternalIP, field.TypeString, value)
+		_node.ExternalIP = value
+	}
 	if value, ok := hc.mutation.Platform(); ok {
 		_spec.SetField(host.FieldPlatform, field.TypeEnum, value)
 		_node.Platform = value
@@ -506,6 +524,24 @@ func (u *HostUpsert) ClearPrimaryIP() *HostUpsert {
 	return u
 }
 
+// SetExternalIP sets the "external_ip" field.
+func (u *HostUpsert) SetExternalIP(v string) *HostUpsert {
+	u.Set(host.FieldExternalIP, v)
+	return u
+}
+
+// UpdateExternalIP sets the "external_ip" field to the value that was provided on create.
+func (u *HostUpsert) UpdateExternalIP() *HostUpsert {
+	u.SetExcluded(host.FieldExternalIP)
+	return u
+}
+
+// ClearExternalIP clears the value of the "external_ip" field.
+func (u *HostUpsert) ClearExternalIP() *HostUpsert {
+	u.SetNull(host.FieldExternalIP)
+	return u
+}
+
 // SetPlatform sets the "platform" field.
 func (u *HostUpsert) SetPlatform(v c2pb.Host_Platform) *HostUpsert {
 	u.Set(host.FieldPlatform, v)
@@ -648,6 +684,27 @@ func (u *HostUpsertOne) UpdatePrimaryIP() *HostUpsertOne {
 func (u *HostUpsertOne) ClearPrimaryIP() *HostUpsertOne {
 	return u.Update(func(s *HostUpsert) {
 		s.ClearPrimaryIP()
+	})
+}
+
+// SetExternalIP sets the "external_ip" field.
+func (u *HostUpsertOne) SetExternalIP(v string) *HostUpsertOne {
+	return u.Update(func(s *HostUpsert) {
+		s.SetExternalIP(v)
+	})
+}
+
+// UpdateExternalIP sets the "external_ip" field to the value that was provided on create.
+func (u *HostUpsertOne) UpdateExternalIP() *HostUpsertOne {
+	return u.Update(func(s *HostUpsert) {
+		s.UpdateExternalIP()
+	})
+}
+
+// ClearExternalIP clears the value of the "external_ip" field.
+func (u *HostUpsertOne) ClearExternalIP() *HostUpsertOne {
+	return u.Update(func(s *HostUpsert) {
+		s.ClearExternalIP()
 	})
 }
 
@@ -964,6 +1021,27 @@ func (u *HostUpsertBulk) UpdatePrimaryIP() *HostUpsertBulk {
 func (u *HostUpsertBulk) ClearPrimaryIP() *HostUpsertBulk {
 	return u.Update(func(s *HostUpsert) {
 		s.ClearPrimaryIP()
+	})
+}
+
+// SetExternalIP sets the "external_ip" field.
+func (u *HostUpsertBulk) SetExternalIP(v string) *HostUpsertBulk {
+	return u.Update(func(s *HostUpsert) {
+		s.SetExternalIP(v)
+	})
+}
+
+// UpdateExternalIP sets the "external_ip" field to the value that was provided on create.
+func (u *HostUpsertBulk) UpdateExternalIP() *HostUpsertBulk {
+	return u.Update(func(s *HostUpsert) {
+		s.UpdateExternalIP()
+	})
+}
+
+// ClearExternalIP clears the value of the "external_ip" field.
+func (u *HostUpsertBulk) ClearExternalIP() *HostUpsertBulk {
+	return u.Update(func(s *HostUpsert) {
+		s.ClearExternalIP()
 	})
 }
 

--- a/tavern/internal/ent/host_update.go
+++ b/tavern/internal/ent/host_update.go
@@ -94,6 +94,26 @@ func (hu *HostUpdate) ClearPrimaryIP() *HostUpdate {
 	return hu
 }
 
+// SetExternalIP sets the "external_ip" field.
+func (hu *HostUpdate) SetExternalIP(s string) *HostUpdate {
+	hu.mutation.SetExternalIP(s)
+	return hu
+}
+
+// SetNillableExternalIP sets the "external_ip" field if the given value is not nil.
+func (hu *HostUpdate) SetNillableExternalIP(s *string) *HostUpdate {
+	if s != nil {
+		hu.SetExternalIP(*s)
+	}
+	return hu
+}
+
+// ClearExternalIP clears the value of the "external_ip" field.
+func (hu *HostUpdate) ClearExternalIP() *HostUpdate {
+	hu.mutation.ClearExternalIP()
+	return hu
+}
+
 // SetPlatform sets the "platform" field.
 func (hu *HostUpdate) SetPlatform(cp c2pb.Host_Platform) *HostUpdate {
 	hu.mutation.SetPlatform(cp)
@@ -398,6 +418,12 @@ func (hu *HostUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if hu.mutation.PrimaryIPCleared() {
 		_spec.ClearField(host.FieldPrimaryIP, field.TypeString)
+	}
+	if value, ok := hu.mutation.ExternalIP(); ok {
+		_spec.SetField(host.FieldExternalIP, field.TypeString, value)
+	}
+	if hu.mutation.ExternalIPCleared() {
+		_spec.ClearField(host.FieldExternalIP, field.TypeString)
 	}
 	if value, ok := hu.mutation.Platform(); ok {
 		_spec.SetField(host.FieldPlatform, field.TypeEnum, value)
@@ -710,6 +736,26 @@ func (huo *HostUpdateOne) SetNillablePrimaryIP(s *string) *HostUpdateOne {
 // ClearPrimaryIP clears the value of the "primary_ip" field.
 func (huo *HostUpdateOne) ClearPrimaryIP() *HostUpdateOne {
 	huo.mutation.ClearPrimaryIP()
+	return huo
+}
+
+// SetExternalIP sets the "external_ip" field.
+func (huo *HostUpdateOne) SetExternalIP(s string) *HostUpdateOne {
+	huo.mutation.SetExternalIP(s)
+	return huo
+}
+
+// SetNillableExternalIP sets the "external_ip" field if the given value is not nil.
+func (huo *HostUpdateOne) SetNillableExternalIP(s *string) *HostUpdateOne {
+	if s != nil {
+		huo.SetExternalIP(*s)
+	}
+	return huo
+}
+
+// ClearExternalIP clears the value of the "external_ip" field.
+func (huo *HostUpdateOne) ClearExternalIP() *HostUpdateOne {
+	huo.mutation.ClearExternalIP()
 	return huo
 }
 
@@ -1047,6 +1093,12 @@ func (huo *HostUpdateOne) sqlSave(ctx context.Context) (_node *Host, err error) 
 	}
 	if huo.mutation.PrimaryIPCleared() {
 		_spec.ClearField(host.FieldPrimaryIP, field.TypeString)
+	}
+	if value, ok := huo.mutation.ExternalIP(); ok {
+		_spec.SetField(host.FieldExternalIP, field.TypeString, value)
+	}
+	if huo.mutation.ExternalIPCleared() {
+		_spec.ClearField(host.FieldExternalIP, field.TypeString)
 	}
 	if value, ok := huo.mutation.Platform(); ok {
 		_spec.SetField(host.FieldPlatform, field.TypeEnum, value)

--- a/tavern/internal/ent/migrate/schema.go
+++ b/tavern/internal/ent/migrate/schema.go
@@ -60,6 +60,7 @@ var (
 		{Name: "identifier", Type: field.TypeString, Unique: true},
 		{Name: "name", Type: field.TypeString, Nullable: true},
 		{Name: "primary_ip", Type: field.TypeString, Nullable: true},
+		{Name: "external_ip", Type: field.TypeString, Nullable: true},
 		{Name: "platform", Type: field.TypeEnum, Enums: []string{"PLATFORM_BSD", "PLATFORM_LINUX", "PLATFORM_MACOS", "PLATFORM_UNSPECIFIED", "PLATFORM_WINDOWS"}},
 		{Name: "last_seen_at", Type: field.TypeTime, Nullable: true},
 	}

--- a/tavern/internal/ent/mutation.go
+++ b/tavern/internal/ent/mutation.go
@@ -1844,6 +1844,7 @@ type HostMutation struct {
 	identifier         *string
 	name               *string
 	primary_ip         *string
+	external_ip        *string
 	platform           *c2pb.Host_Platform
 	last_seen_at       *time.Time
 	clearedFields      map[string]struct{}
@@ -2169,6 +2170,55 @@ func (m *HostMutation) PrimaryIPCleared() bool {
 func (m *HostMutation) ResetPrimaryIP() {
 	m.primary_ip = nil
 	delete(m.clearedFields, host.FieldPrimaryIP)
+}
+
+// SetExternalIP sets the "external_ip" field.
+func (m *HostMutation) SetExternalIP(s string) {
+	m.external_ip = &s
+}
+
+// ExternalIP returns the value of the "external_ip" field in the mutation.
+func (m *HostMutation) ExternalIP() (r string, exists bool) {
+	v := m.external_ip
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExternalIP returns the old "external_ip" field's value of the Host entity.
+// If the Host object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HostMutation) OldExternalIP(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExternalIP is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExternalIP requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExternalIP: %w", err)
+	}
+	return oldValue.ExternalIP, nil
+}
+
+// ClearExternalIP clears the value of the "external_ip" field.
+func (m *HostMutation) ClearExternalIP() {
+	m.external_ip = nil
+	m.clearedFields[host.FieldExternalIP] = struct{}{}
+}
+
+// ExternalIPCleared returns if the "external_ip" field was cleared in this mutation.
+func (m *HostMutation) ExternalIPCleared() bool {
+	_, ok := m.clearedFields[host.FieldExternalIP]
+	return ok
+}
+
+// ResetExternalIP resets all changes to the "external_ip" field.
+func (m *HostMutation) ResetExternalIP() {
+	m.external_ip = nil
+	delete(m.clearedFields, host.FieldExternalIP)
 }
 
 // SetPlatform sets the "platform" field.
@@ -2560,7 +2610,7 @@ func (m *HostMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HostMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 8)
 	if m.created_at != nil {
 		fields = append(fields, host.FieldCreatedAt)
 	}
@@ -2575,6 +2625,9 @@ func (m *HostMutation) Fields() []string {
 	}
 	if m.primary_ip != nil {
 		fields = append(fields, host.FieldPrimaryIP)
+	}
+	if m.external_ip != nil {
+		fields = append(fields, host.FieldExternalIP)
 	}
 	if m.platform != nil {
 		fields = append(fields, host.FieldPlatform)
@@ -2600,6 +2653,8 @@ func (m *HostMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case host.FieldPrimaryIP:
 		return m.PrimaryIP()
+	case host.FieldExternalIP:
+		return m.ExternalIP()
 	case host.FieldPlatform:
 		return m.Platform()
 	case host.FieldLastSeenAt:
@@ -2623,6 +2678,8 @@ func (m *HostMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldName(ctx)
 	case host.FieldPrimaryIP:
 		return m.OldPrimaryIP(ctx)
+	case host.FieldExternalIP:
+		return m.OldExternalIP(ctx)
 	case host.FieldPlatform:
 		return m.OldPlatform(ctx)
 	case host.FieldLastSeenAt:
@@ -2670,6 +2727,13 @@ func (m *HostMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetPrimaryIP(v)
+		return nil
+	case host.FieldExternalIP:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExternalIP(v)
 		return nil
 	case host.FieldPlatform:
 		v, ok := value.(c2pb.Host_Platform)
@@ -2721,6 +2785,9 @@ func (m *HostMutation) ClearedFields() []string {
 	if m.FieldCleared(host.FieldPrimaryIP) {
 		fields = append(fields, host.FieldPrimaryIP)
 	}
+	if m.FieldCleared(host.FieldExternalIP) {
+		fields = append(fields, host.FieldExternalIP)
+	}
 	if m.FieldCleared(host.FieldLastSeenAt) {
 		fields = append(fields, host.FieldLastSeenAt)
 	}
@@ -2743,6 +2810,9 @@ func (m *HostMutation) ClearField(name string) error {
 		return nil
 	case host.FieldPrimaryIP:
 		m.ClearPrimaryIP()
+		return nil
+	case host.FieldExternalIP:
+		m.ClearExternalIP()
 		return nil
 	case host.FieldLastSeenAt:
 		m.ClearLastSeenAt()
@@ -2769,6 +2839,9 @@ func (m *HostMutation) ResetField(name string) error {
 		return nil
 	case host.FieldPrimaryIP:
 		m.ResetPrimaryIP()
+		return nil
+	case host.FieldExternalIP:
+		m.ResetExternalIP()
 		return nil
 	case host.FieldPlatform:
 		m.ResetPlatform()

--- a/tavern/internal/ent/schema/host.go
+++ b/tavern/internal/ent/schema/host.go
@@ -34,6 +34,12 @@ func (Host) Fields() []ent.Field {
 				entgql.Skip(entgql.SkipMutationUpdateInput),
 			).
 			Comment("Primary interface IP address reported by the agent."),
+		field.String("external_ip").
+			Optional().
+			Annotations(
+				entgql.Skip(entgql.SkipMutationUpdateInput),
+			).
+			Comment("Incoming IP from Proxy. Will return first proxy IP if multiple."),
 		field.Enum("platform").
 			GoType(c2pb.Host_Platform(0)).
 			Annotations(

--- a/tavern/internal/graphql/generated/ent.generated.go
+++ b/tavern/internal/graphql/generated/ent.generated.go
@@ -1597,6 +1597,8 @@ func (ec *executionContext) fieldContext_Beacon_host(_ context.Context, field gr
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":
@@ -2345,6 +2347,47 @@ func (ec *executionContext) fieldContext_Host_primaryIP(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _Host_externalIP(ctx context.Context, field graphql.CollectedField, obj *ent.Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_externalIP(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExternalIP, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_externalIP(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Host_platform(ctx context.Context, field graphql.CollectedField, obj *ent.Host) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Host_platform(ctx, field)
 	if err != nil {
@@ -3058,6 +3101,8 @@ func (ec *executionContext) fieldContext_HostCredential_host(_ context.Context, 
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":
@@ -3587,6 +3632,8 @@ func (ec *executionContext) fieldContext_HostFile_host(_ context.Context, field 
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":
@@ -4251,6 +4298,8 @@ func (ec *executionContext) fieldContext_HostProcess_host(_ context.Context, fie
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":
@@ -5179,6 +5228,8 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":
@@ -8091,6 +8142,8 @@ func (ec *executionContext) fieldContext_Tag_hosts(_ context.Context, field grap
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":
@@ -14058,7 +14111,7 @@ func (ec *executionContext) unmarshalInputHostWhereInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "lastModifiedAt", "lastModifiedAtNEQ", "lastModifiedAtIn", "lastModifiedAtNotIn", "lastModifiedAtGT", "lastModifiedAtGTE", "lastModifiedAtLT", "lastModifiedAtLTE", "identifier", "identifierNEQ", "identifierIn", "identifierNotIn", "identifierGT", "identifierGTE", "identifierLT", "identifierLTE", "identifierContains", "identifierHasPrefix", "identifierHasSuffix", "identifierEqualFold", "identifierContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameIsNil", "nameNotNil", "nameEqualFold", "nameContainsFold", "primaryIP", "primaryIPNEQ", "primaryIPIn", "primaryIPNotIn", "primaryIPGT", "primaryIPGTE", "primaryIPLT", "primaryIPLTE", "primaryIPContains", "primaryIPHasPrefix", "primaryIPHasSuffix", "primaryIPIsNil", "primaryIPNotNil", "primaryIPEqualFold", "primaryIPContainsFold", "platform", "platformNEQ", "platformIn", "platformNotIn", "lastSeenAt", "lastSeenAtNEQ", "lastSeenAtIn", "lastSeenAtNotIn", "lastSeenAtGT", "lastSeenAtGTE", "lastSeenAtLT", "lastSeenAtLTE", "lastSeenAtIsNil", "lastSeenAtNotNil", "hasTags", "hasTagsWith", "hasBeacons", "hasBeaconsWith", "hasFiles", "hasFilesWith", "hasProcesses", "hasProcessesWith", "hasCredentials", "hasCredentialsWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "lastModifiedAt", "lastModifiedAtNEQ", "lastModifiedAtIn", "lastModifiedAtNotIn", "lastModifiedAtGT", "lastModifiedAtGTE", "lastModifiedAtLT", "lastModifiedAtLTE", "identifier", "identifierNEQ", "identifierIn", "identifierNotIn", "identifierGT", "identifierGTE", "identifierLT", "identifierLTE", "identifierContains", "identifierHasPrefix", "identifierHasSuffix", "identifierEqualFold", "identifierContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameIsNil", "nameNotNil", "nameEqualFold", "nameContainsFold", "primaryIP", "primaryIPNEQ", "primaryIPIn", "primaryIPNotIn", "primaryIPGT", "primaryIPGTE", "primaryIPLT", "primaryIPLTE", "primaryIPContains", "primaryIPHasPrefix", "primaryIPHasSuffix", "primaryIPIsNil", "primaryIPNotNil", "primaryIPEqualFold", "primaryIPContainsFold", "externalIP", "externalIPNEQ", "externalIPIn", "externalIPNotIn", "externalIPGT", "externalIPGTE", "externalIPLT", "externalIPLTE", "externalIPContains", "externalIPHasPrefix", "externalIPHasSuffix", "externalIPIsNil", "externalIPNotNil", "externalIPEqualFold", "externalIPContainsFold", "platform", "platformNEQ", "platformIn", "platformNotIn", "lastSeenAt", "lastSeenAtNEQ", "lastSeenAtIn", "lastSeenAtNotIn", "lastSeenAtGT", "lastSeenAtGTE", "lastSeenAtLT", "lastSeenAtLTE", "lastSeenAtIsNil", "lastSeenAtNotNil", "hasTags", "hasTagsWith", "hasBeacons", "hasBeaconsWith", "hasFiles", "hasFilesWith", "hasProcesses", "hasProcessesWith", "hasCredentials", "hasCredentialsWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -14555,6 +14608,111 @@ func (ec *executionContext) unmarshalInputHostWhereInput(ctx context.Context, ob
 				return it, err
 			}
 			it.PrimaryIPContainsFold = data
+		case "externalIP":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIP"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIP = data
+		case "externalIPNEQ":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPNEQ = data
+		case "externalIPIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPIn = data
+		case "externalIPNotIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPNotIn = data
+		case "externalIPGT":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPGT = data
+		case "externalIPGTE":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPGTE = data
+		case "externalIPLT":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPLT = data
+		case "externalIPLTE":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPLTE = data
+		case "externalIPContains":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPContains = data
+		case "externalIPHasPrefix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPHasPrefix = data
+		case "externalIPHasSuffix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPHasSuffix = data
+		case "externalIPIsNil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPIsNil = data
+		case "externalIPNotNil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPNotNil = data
+		case "externalIPEqualFold":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPEqualFold = data
+		case "externalIPContainsFold":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("externalIPContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExternalIPContainsFold = data
 		case "platform":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("platform"))
 			data, err := ec.unmarshalOHostPlatform2ᚖrealmᚗpubᚋtavernᚋinternalᚋc2ᚋc2pbᚐHost_Platform(ctx, v)
@@ -19377,6 +19535,8 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 			out.Values[i] = ec._Host_name(ctx, field, obj)
 		case "primaryIP":
 			out.Values[i] = ec._Host_primaryIP(ctx, field, obj)
+		case "externalIP":
+			out.Values[i] = ec._Host_externalIP(ctx, field, obj)
 		case "platform":
 			out.Values[i] = ec._Host_platform(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/tavern/internal/graphql/generated/mutation.generated.go
+++ b/tavern/internal/graphql/generated/mutation.generated.go
@@ -902,6 +902,8 @@ func (ec *executionContext) fieldContext_Mutation_updateHost(ctx context.Context
 				return ec.fieldContext_Host_name(ctx, field)
 			case "primaryIP":
 				return ec.fieldContext_Host_primaryIP(ctx, field)
+			case "externalIP":
+				return ec.fieldContext_Host_externalIP(ctx, field)
 			case "platform":
 				return ec.fieldContext_Host_platform(ctx, field)
 			case "lastSeenAt":

--- a/tavern/internal/graphql/generated/root_.generated.go
+++ b/tavern/internal/graphql/generated/root_.generated.go
@@ -73,6 +73,7 @@ type ComplexityRoot struct {
 		Beacons        func(childComplexity int) int
 		CreatedAt      func(childComplexity int) int
 		Credentials    func(childComplexity int) int
+		ExternalIP     func(childComplexity int) int
 		Files          func(childComplexity int) int
 		ID             func(childComplexity int) int
 		Identifier     func(childComplexity int) int
@@ -475,6 +476,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.Credentials(childComplexity), true
+
+	case "Host.externalIP":
+		if e.complexity.Host.ExternalIP == nil {
+			break
+		}
+
+		return e.complexity.Host.ExternalIP(childComplexity), true
 
 	case "Host.files":
 		if e.complexity.Host.Files == nil {
@@ -2371,6 +2379,10 @@ type Host implements Node {
   """
   primaryIP: String
   """
+  Incoming IP from Proxy. Will return first proxy IP if multiple.
+  """
+  externalIP: String
+  """
   Platform the agent is operating on.
   """
   platform: HostPlatform!
@@ -3172,6 +3184,24 @@ input HostWhereInput {
   primaryIPNotNil: Boolean
   primaryIPEqualFold: String
   primaryIPContainsFold: String
+  """
+  external_ip field predicates
+  """
+  externalIP: String
+  externalIPNEQ: String
+  externalIPIn: [String!]
+  externalIPNotIn: [String!]
+  externalIPGT: String
+  externalIPGTE: String
+  externalIPLT: String
+  externalIPLTE: String
+  externalIPContains: String
+  externalIPHasPrefix: String
+  externalIPHasSuffix: String
+  externalIPIsNil: Boolean
+  externalIPNotNil: Boolean
+  externalIPEqualFold: String
+  externalIPContainsFold: String
   """
   platform field predicates
   """

--- a/tavern/internal/graphql/schema.graphql
+++ b/tavern/internal/graphql/schema.graphql
@@ -511,6 +511,10 @@ type Host implements Node {
   """
   primaryIP: String
   """
+  Incoming IP from Proxy. Will return first proxy IP if multiple.
+  """
+  externalIP: String
+  """
   Platform the agent is operating on.
   """
   platform: HostPlatform!
@@ -1312,6 +1316,24 @@ input HostWhereInput {
   primaryIPNotNil: Boolean
   primaryIPEqualFold: String
   primaryIPContainsFold: String
+  """
+  external_ip field predicates
+  """
+  externalIP: String
+  externalIPNEQ: String
+  externalIPIn: [String!]
+  externalIPNotIn: [String!]
+  externalIPGT: String
+  externalIPGTE: String
+  externalIPLT: String
+  externalIPLTE: String
+  externalIPContains: String
+  externalIPHasPrefix: String
+  externalIPHasSuffix: String
+  externalIPIsNil: Boolean
+  externalIPNotNil: Boolean
+  externalIPEqualFold: String
+  externalIPContainsFold: String
   """
   platform field predicates
   """

--- a/tavern/internal/graphql/schema/ent.graphql
+++ b/tavern/internal/graphql/schema/ent.graphql
@@ -506,6 +506,10 @@ type Host implements Node {
   """
   primaryIP: String
   """
+  Incoming IP from Proxy. Will return first proxy IP if multiple.
+  """
+  externalIP: String
+  """
   Platform the agent is operating on.
   """
   platform: HostPlatform!
@@ -1307,6 +1311,24 @@ input HostWhereInput {
   primaryIPNotNil: Boolean
   primaryIPEqualFold: String
   primaryIPContainsFold: String
+  """
+  external_ip field predicates
+  """
+  externalIP: String
+  externalIPNEQ: String
+  externalIPIn: [String!]
+  externalIPNotIn: [String!]
+  externalIPGT: String
+  externalIPGTE: String
+  externalIPLT: String
+  externalIPLTE: String
+  externalIPContains: String
+  externalIPHasPrefix: String
+  externalIPHasSuffix: String
+  externalIPIsNil: Boolean
+  externalIPNotNil: Boolean
+  externalIPEqualFold: String
+  externalIPContainsFold: String
   """
   platform field predicates
   """

--- a/tavern/internal/www/schema.graphql
+++ b/tavern/internal/www/schema.graphql
@@ -511,6 +511,10 @@ type Host implements Node {
   """
   primaryIP: String
   """
+  Incoming IP from Proxy. Will return first proxy IP if multiple.
+  """
+  externalIP: String
+  """
   Platform the agent is operating on.
   """
   platform: HostPlatform!
@@ -1312,6 +1316,24 @@ input HostWhereInput {
   primaryIPNotNil: Boolean
   primaryIPEqualFold: String
   primaryIPContainsFold: String
+  """
+  external_ip field predicates
+  """
+  externalIP: String
+  externalIPNEQ: String
+  externalIPIn: [String!]
+  externalIPNotIn: [String!]
+  externalIPGT: String
+  externalIPGTE: String
+  externalIPLT: String
+  externalIPLTE: String
+  externalIPContains: String
+  externalIPHasPrefix: String
+  externalIPHasSuffix: String
+  externalIPIsNil: Boolean
+  externalIPNotNil: Boolean
+  externalIPEqualFold: String
+  externalIPContainsFold: String
   """
   platform field predicates
   """


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Folks displayed an interest in having the external IP of the host available. This change will log the incoming IP at an `externalIP` in the host.

If `X-Forwarded-For` is set, the first IP in the list will be used. Otherwise, the remote IP from the connection is used.

First Example using Direct Connection (VPN IP)

<img width="400" alt="Screenshot 2025-03-22 at 10 47 18 PM" src="https://github.com/user-attachments/assets/2e8b72a6-d3b7-4344-9da6-66745f16f289" />

Second Example (GCP) using Header (VPN IP)

<img width="379" alt="Screenshot 2025-03-22 at 10 51 28 PM" src="https://github.com/user-attachments/assets/75e6c354-a860-4a07-a0fa-c07981bc5713" />

#### Which issue(s) this PR fixes:
Fixes #879 
