### PR TITLE
Fix Terraform When Not Using Auth

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -246,7 +246,7 @@ resource "google_cloud_run_service" "tavern" {
         }
         env {
           name = "OAUTH_DOMAIN"
-          value = format("https://%s", var.oauth_domain)
+          value = length(var.oauth_domain) > 0 ? format("https://%s", var.oauth_domain) : ""
         }
         env {
           name = "GCP_PROJECT_ID"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When deploying GCP without Auth, there is an error that the OAuth is incorrectly set. When investigating, not setting OAuth still sets the domain as `https://`. Now if the domain var is not set, the env field will also not be set.

#### Which issue(s) this PR fixes:
N/A