### PR TITLE
Make file.write consistent with other methods and overwrite instead of error is "to" file exists

### DIFF
--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -409,7 +409,8 @@ Unimplemented.
 `file.write(path: str, content: str) -> None`
 
 The <b>file.write</b> method writes to a given file path with the given content.
-If a file or directory already exists at this path, the method will fail.
+If a file already exists at this path, the method will overwite it. If a directory
+already exists at the path the method will error.
 
 ### file.find
 
@@ -559,7 +560,6 @@ ssh_copy will return `"Sucess"` if successful and `"Failed to run handle_ssh_cop
 If the connection is successful but the copy writes a file error will be returned.
 ssh_copy will overwrite the remote file if it exists.
 The file directory the `dst` file exists in must exist in order for ssh_copy to work.
-
 
 ### pivot.ssh_exec
 

--- a/implants/lib/eldritch/src/file/write_impl.rs
+++ b/implants/lib/eldritch/src/file/write_impl.rs
@@ -1,10 +1,7 @@
 use anyhow::{anyhow, Result};
-use std::{fs::File, io::Write, path::Path};
+use std::{fs::File, io::Write};
 
 pub fn write(path: String, content: String) -> Result<()> {
-    if Path::new(&path).exists() {
-        return Err(anyhow!("File already exists"));
-    }
     let mut f = File::create(&path).map_err(|err| anyhow!("File could not be created: {err}"))?;
     f.write_all(content.as_bytes())
         .map_err(|err| anyhow!("Failed to write to file: {err}"))?;
@@ -13,6 +10,8 @@ pub fn write(path: String, content: String) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Seek};
+
     use super::*;
     use tempfile::{tempdir, NamedTempFile};
 
@@ -32,12 +31,18 @@ mod tests {
     }
 
     #[test]
-    fn test_write_fail_file_exists() -> anyhow::Result<()> {
-        // Attempt to write to a file that already exists and fail
-        let tmp_file = NamedTempFile::new()?;
+    fn test_write_file_exists() -> anyhow::Result<()> {
+        // Attempt to write to a file that already exists
+        let mut tmp_file = NamedTempFile::new()?;
+        tmp_file.write_all("this is a very very very long string".as_bytes())?;
         let path = String::from(tmp_file.path().to_str().unwrap()).clone();
 
-        assert!(write(path, "Hello World!".to_string()).is_err());
+        assert!(write(path, "Hello World!".to_string()).is_ok());
+        let mut tmp_str = String::new();
+        // be kind and rewind!
+        tmp_file.seek(std::io::SeekFrom::Start(0))?;
+        tmp_file.read_to_string(&mut tmp_str)?;
+        assert_eq!(tmp_str, "Hello World!".to_string());
         tmp_file.close()?;
         Ok(())
     }


### PR DESCRIPTION

/kind bug
