### PR TITLE
Don't error if remove_file fails.

### DIFF
--- a/implants/lib/eldritch/src/pivot/mod.rs
+++ b/implants/lib/eldritch/src/pivot/mod.rs
@@ -149,7 +149,7 @@ impl Session {
         channel.request_subsystem(true, "sftp").await.unwrap();
         let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
 
-        sftp.remove_file(dst).await?;
+        let _ = sftp.remove_file(dst).await;
         let mut dst_file = sftp.create(dst).await?;
         let mut src_file = tokio::io::BufReader::new(tokio::fs::File::open(src).await?);
         let _bytes_copied = tokio::io::copy_buf(&mut src_file, &mut dst_file).await?;


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Don't error ssh_copy if dest file doesn't exist.

#### Which issue(s) this PR fixes:
Fixes #917 
