### PR TITLE
Add a  method to TaskHandle to ensure tokio JoinSets are awaited

### DIFF
--- a/implants/imix/src/agent.rs
+++ b/implants/imix/src/agent.rs
@@ -66,6 +66,7 @@ impl<T: Transport + 'static> Agent<T> {
             if self.handles[idx].is_finished() {
                 let mut handle = self.handles.remove(idx);
                 handle.report(&mut tavern).await?;
+                handle.join().await;
                 continue;
             }
 

--- a/implants/imix/src/task.rs
+++ b/implants/imix/src/task.rs
@@ -33,6 +33,13 @@ impl TaskHandle {
         self.runtime.is_finished()
     }
 
+    // Join all the JoinSets within the pool on the TaskHandle.
+    // WARNING: this will await until the entire pool is complete
+    // it is advised to check `is_finished` before calling this method.
+    pub async fn join(&mut self) {
+        while self.pool.join_next().await.is_some() {}
+    }
+
     // Report any available task output.
     // Also responsible for downloading any files requested by the eldritch runtime.
     pub async fn report(&mut self, tavern: &mut (impl Transport + 'static)) -> Result<()> {


### PR DESCRIPTION
Even though the tokio JoinSet docs claim

```
The provided future will start running in the background immediately
when this method is called, even if you don't await anything on this
`JoinSet`.
```

We are seeing some sort of race condition on faster tomes where this behavior is not occurring(and thus the JoinSet for reporting back output is never executing). To fix this I added a `join` method for `TaskHandle` so that way in the `Agent.report` method we can call it on finished `TaskHandle`s. This should be safe from hanging the thread as `is_finished` (which is called before) ensures that the pool is empty and the `Runtime`'s `JoinHandle` is finsihed.

/kind bug
Fixes #754 