### PR TITLE
Windown vcruntime

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -82,6 +82,7 @@ tonic = { git = "https://github.com/hyperium/tonic.git", rev = "07e4ee1" }
 tonic-build = "0.10"
 trait-variant = "0.1.1"
 uuid = "1.5.0"
+static_vcruntime = "2.0"
 which = "4.4.2"
 whoami = { version = "1.5.1", default-features = false }
 windows-service = "0.6.0"

--- a/implants/golem/Cargo.toml
+++ b/implants/golem/Cargo.toml
@@ -23,3 +23,7 @@ lsp-types = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
+
+
+[target.'cfg(target_os = "windows")'.build-dependencies]
+static_vcruntime = { workspace = true }

--- a/implants/golem/build.rs
+++ b/implants/golem/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(target_os = "windows")]
+    static_vcruntime::metabuild();
+}

--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -25,6 +25,10 @@ pretty_env_logger = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-service = "0.6.0"
 
+
+[target.'cfg(target_os = "windows")'.build-dependencies]
+static_vcruntime = { workspace = true }
+
 [dev-dependencies]
 httptest = { workspace = true }
 tempfile = { workspace = true }

--- a/implants/imix/build.rs
+++ b/implants/imix/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(target_os = "windows")]
+    static_vcruntime::metabuild();
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
Ran into issue where golem and imix would crash with error `VCRUNTIME140.dll` was not found.
Had to add specific configuration to statically compile `vcruntime`

![Pasted image 20250505172838](https://github.com/user-attachments/assets/f8a83e09-65de-40bc-9e52-ef603dce58b7)


#### Which issue(s) this PR fixes:
Fixes #
