### PR TITLE
Fix: Update CI workflow to address macOS failures and deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
     - name: 🔎 Run tests
       run: |
         cd ./implants/ &&
-        cargo fmt --check &&
-        cargo llvm-cov nextest --lcov --output-path lcov.info
+        cargo +stable fmt --check &&
+        cargo +stable llvm-cov nextest --lcov --output-path lcov.info
     - name: 📶 Upload Coverage Results
       uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 'stable'
+        default: false
+        profile: minimal
         components: rustfmt, clippy
     - name: Setup Rust (Loader)
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,8 @@ jobs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 'stable'
-        default: false
+        toolchain: '1.84.1'
+        default: true
         profile: minimal
         components: rustfmt, clippy
     - name: Setup Rust (Loader)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,19 +46,15 @@ jobs:
       name: 👾 Disable defender
       shell: powershell
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: '1.84.1'
-        default: true
-        profile: minimal
         components: rustfmt, clippy
     - name: Setup Rust (Loader)
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       if: matrix.os == 'windows-latest'
       with:
         toolchain: 'nightly-2025-01-31'
-        default: false
-        profile: minimal
         components: rust-src
     - name: rust-cache
       uses: Swatinem/rust-cache@v2
@@ -71,7 +67,7 @@ jobs:
         cd ./bin/reflective_loader/
         cargo +nightly-2025-01-31 build --release -Z build-std=core,compiler_builtins -Z build-std-features=compiler-builtins-mem
     - name: Install latest nextest & cargo-llvm-cov release
-      uses: taiki-e/install-action@v2.17.7
+      uses: taiki-e/install-action@v2
       with:
         tool: nextest,cargo-llvm-cov
     - name: 🔎 Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: '1.84.1'
+        toolchain: 'stable'
         components: rustfmt, clippy
     - name: Setup Rust (Loader)
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,8 @@ jobs:
       if: matrix.os == 'windows-latest'
       with:
         toolchain: 'nightly-2025-01-31'
+        default: false
+        profile: minimal
         components: rust-src
     - name: rust-cache
       uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
- Updated `taiki-e/install-action` from `v2.17.7` to `v2` to potentially resolve issues with `nextest` and `cargo-llvm-cov` installation on macOS.
- Replaced archived `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@master` for Rust toolchain setup. This also addresses `set-output` deprecation warnings.

These changes aim to fix the failing `implants (macOS-latest)` CI job and modernize the workflow dependencies.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
