### PR TITLE
hard lock generic-array

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -16,7 +16,6 @@ host_unique = { path = "./lib/host_unique" }
 pb = { path = "./lib/pb" }
 
 aes = "0.8.3"
-generic-array = "=0.14.7"
 allocative = "0.3.2"
 allocative_derive = "0.3.2"
 anyhow = "1.0.65"

--- a/implants/lib/eldritch/Cargo.toml
+++ b/implants/lib/eldritch/Cargo.toml
@@ -12,6 +12,7 @@ print_stdout = []
 pb = { workspace = true }
 transport = { workspace = true }
 
+generic-array = "=0.14.7"
 aes = { workspace = true }
 allocative = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
<img width="1074" height="176" alt="image" src="https://github.com/user-attachments/assets/26f07912-2896-415a-9825-393ebf9387bb" />
The aes dependency uses generic-array which made a breaking change.

https://github.com/RustCrypto/block-ciphers/issues/509

This hard locks the dep while we wait for aes to update.

#### Which issue(s) this PR fixes:
Fixes #
