### PR TITLE
[Bug] Fix Windows imix agent debug output

### DIFF
--- a/implants/imix/src/main.rs
+++ b/implants/imix/src/main.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(all(not(debug_assertions), not(feature = "win_service")), windows_subsystem = "windows")]
+#![cfg_attr(
+    all(not(debug_assertions), not(feature = "win_service")),
+    windows_subsystem = "windows"
+)]
 #![deny(warnings)]
 
 #[cfg(all(feature = "win_service", windows))]


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Uses the windows subsystem only on production binaries. Debug binaries keep console subsystem

#### Which issue(s) this PR fixes:

Fixes #1028 
