### PR TITLE
[bug] Fix revshell infinite loop

### DIFF
--- a/implants/lib/eldritch/src/runtime/messages/reverse_shell_pty.rs
+++ b/implants/lib/eldritch/src/runtime/messages/reverse_shell_pty.rs
@@ -119,6 +119,8 @@ impl AsyncDispatcher for ReverseShellPTYMessage {
                         Err(TryRecvError::Disconnected) => {
                             #[cfg(debug_assertions)]
                             log::info!("closing output stream, exit channel closed");
+
+                            break;
                         }
                     }
 


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Prevents infinite loop in a thread when calling revshell on a non-supported transport.

#### Which issue(s) this PR fixes:

Fixes #1030 
