### PR TITLE
Fix Web and Binary REPL usability issues

### DIFF
--- a/docs/assets/eldritch-repl/index.html
+++ b/docs/assets/eldritch-repl/index.html
@@ -18,6 +18,10 @@
             word-wrap: break-word;
             outline: none;
         }
+        #current-line {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
         .prompt {
             color: #569cd6;
             margin-right: 0px; /* Spacing handled by content */
@@ -29,6 +33,16 @@
             background-color: #d4d4d4;
             color: #1e1e1e;
         }
+        /* Visual indicator when not focused */
+        body.not-focused .cursor {
+            background-color: transparent;
+            border: 1px solid #d4d4d4;
+            color: #d4d4d4;
+        }
+        body.not-focused {
+            opacity: 0.8;
+        }
+
         /* Hide the actual input but keep it functional */
         #hidden-input {
             position: absolute;
@@ -57,6 +71,8 @@
 
         // Output handling
         window.repl_print = (s) => {
+            // This is kept for backward compatibility if any direct calls remain,
+            // but the primary output path should now be through handle_key/execute returns.
             printLine(s);
         };
 
@@ -82,8 +98,23 @@
             printLine("Eldritch REPL initialized.\nType code and press Enter.\n");
             render();
 
-            // Focus hidden input
-            document.body.addEventListener('click', () => inputEl.focus());
+            // Focus handling
+            inputEl.addEventListener('focus', () => {
+                document.body.classList.remove('not-focused');
+                render(); // Re-render to update cursor style if needed
+            });
+
+            inputEl.addEventListener('blur', () => {
+                document.body.classList.add('not-focused');
+                render();
+            });
+
+            // Focus hidden input on click anywhere
+            document.body.addEventListener('click', () => {
+                inputEl.focus();
+            });
+
+            // Initial focus
             inputEl.focus();
         }
 
@@ -130,69 +161,30 @@
             if (e.key === 'l' && e.ctrlKey) e.preventDefault();
 
             // Handle Key via Rust
-            // We map JS event to simple "Key" + Modifiers
-            // But WasmRepl expects specific strings for keys it knows, or single chars.
-
             let key = e.key;
 
-            const result = repl.handle_key(key, e.ctrlKey, e.altKey, e.metaKey);
+            // Pass shiftKey to handle_key
+            const result = repl.handle_key(key, e.ctrlKey, e.altKey, e.metaKey, e.shiftKey);
 
-            if (result.should_print && result.output !== undefined) {
-                // Command executed and produced output (or error)
-                // First, commit the current line to the terminal display
-                // Wait, the Repl has already cleared the buffer inside handle_key(Submit)
-                // We need to capture the "what was just typed" to print it to history?
-                // The Repl logic clears buffer on Submit.
-                // Does `Repl` return the submitted code? Yes, `ReplAction::Submit(code)`.
-                // But `handle_key` returns `ExecutionResult`.
-                // We need to print the command that was just executed to the terminal log,
-                // because `render()` will show an empty prompt now.
-                //
-                // Issue: `handle_key` in `wasm.rs` swallows the submitted code.
-                // We probably want to print the *previous* state or the submitted code before showing output.
-                //
-                // FIX: `wasm.rs` should return the code executed OR we assume the UI handles "echo".
-                // In CLI `repl.rs`, we print the buffer before clearing.
-                // In `wasm.rs`, we don't have easy access to the buffer *before* the action unless we query it first.
-                //
-                // Better approach: When `handle_key` returns a result that implies execution,
-                // it should probably include the "echo" of the command if needed?
-                // OR `render()` logic handles the active line, but once submitted, it's gone from `repl`.
-                //
-                // Let's modify JS to:
-                // 1. Get state.
-                // 2. Call handle_key.
-                // 3. If "Submit" happened (how do we know? `should_print` is true usually implies output or error),
-                //    we need to know what was submitted to print ">>> command".
-                //
-                // Actually, `wasm.rs` `execute` could verify if we should echo?
-                // Or simply: The `Repl` engine clears the buffer.
-                // If we want to mimic a terminal, we should print the command to the scrollback.
-                //
-                // I should update `wasm.rs` to include `echo_command` in `ExecutionResult`?
-                // Or I can just manually manage it in JS if I knew what it was.
-                //
-                // Let's modify `wasm.rs` to return `echo: Option<String>` in `ExecutionResult`.
-                // Wait, `repl.rs` `handle_input` returns `Submit(String)`.
-                // `wasm.rs` consumes it.
-                // I will update `wasm.rs` now to pass that back.
+            // Handle clear screen
+            if (result.clear) {
+                termEl.innerHTML = '';
             }
 
-            // Check output
+            // Handle echo (the command or line accepted) FIRST
+            if (result.echo) {
+                printLine(result.echo);
+            }
+
+            // Then output
             if (result.output) {
                 printLine(result.output);
             }
 
-            // If we just submitted, we need to print the *prompt + command* that was submitted?
-            // The `render()` will show a fresh prompt.
-            // The previous command is gone.
-            // THIS IS A PROBLEM.
-            // I need to update `wasm.rs` to return the executed command so I can print it.
-
             // Re-render
             render();
 
-            if (result.should_print) {
+            if (result.output || result.echo) {
                 saveHistory();
             }
         });
@@ -201,26 +193,14 @@
              e.preventDefault();
              const text = (e.clipboardData || window.clipboardData).getData('text');
              if (text) {
-                 // We need to echo the pasted text as prompts?
-                 // `wasm.rs` `handle_paste` returns output.
-                 // But it doesn't return the "echo" of what was pasted.
-                 // If I paste `if True:\n  pass`, I want to see:
-                 // >>> if True:
-                 // ...   pass
-                 // (output)
-                 //
-                 // `handle_paste` in `wasm.rs` is a bit black-box.
-                 // It runs the loop.
-                 // We should probably change `handle_paste` to return a list of "events" to render?
-                 // Or just print inside `handle_paste`?
-                 // `repl_print` prints output.
-                 // We could add `repl_echo(prompt, line)` callback?
-
                  const res = repl.handle_paste(text);
+                 if (res.echo) printLine(res.echo);
                  if (res.output) printLine(res.output);
                  render();
              }
         });
+
+        main();
     </script>
 </body>
 </html>

--- a/implants/lib/eldritchv2/Cargo.toml
+++ b/implants/lib/eldritchv2/Cargo.toml
@@ -16,7 +16,7 @@ crossterm = "0.27"
 wasm-bindgen = "0.2"
 
 [features]
-default = []
+default = ["std"]
 std = []
 
 [[bin]]

--- a/implants/lib/eldritchv2/bin/repl.rs
+++ b/implants/lib/eldritchv2/bin/repl.rs
@@ -95,6 +95,11 @@ fn main() -> io::Result<()> {
                             ReplAction::Render => {
                                 render(&mut stdout, &repl)?;
                             },
+                            ReplAction::ClearScreen => {
+                                stdout.execute(terminal::Clear(ClearType::All))?;
+                                stdout.execute(cursor::MoveTo(0, 0))?;
+                                render(&mut stdout, &repl)?;
+                            },
                             ReplAction::None => {},
                         }
                     }
@@ -121,6 +126,7 @@ fn map_key(key: KeyEvent) -> Option<Input> {
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Input::KillLine),
         KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Input::KillToEnd),
         KeyCode::Char('w') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Input::WordBackspace),
+        KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Input::HistorySearch),
         KeyCode::Char(c) => Some(Input::Char(c)),
         KeyCode::Enter => Some(Input::Enter),
         KeyCode::Backspace => Some(Input::Backspace),

--- a/implants/lib/eldritchv2/tests/test_repl.rs
+++ b/implants/lib/eldritchv2/tests/test_repl.rs
@@ -1,0 +1,64 @@
+#[cfg(test)]
+extern crate alloc;
+
+mod tests {
+    use eldritchv2::repl::{Repl, Input, ReplAction};
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    #[test]
+    fn test_clear_screen() {
+        let mut repl = Repl::new();
+        let action = repl.handle_input(Input::ClearScreen);
+        assert_eq!(action, ReplAction::ClearScreen);
+    }
+
+    #[test]
+    fn test_history_search() {
+        let mut repl = Repl::new();
+        repl.load_history(vec![
+            "print(1)".to_string(),
+            "x = 2".to_string(),
+            "print(3)".to_string(),
+        ]);
+
+        // Start search
+        let action = repl.handle_input(Input::HistorySearch);
+        assert_eq!(action, ReplAction::Render);
+        let state = repl.get_render_state();
+        assert!(state.prompt.contains("reverse-i-search"));
+
+        // Type 'print'
+        repl.handle_input(Input::Char('p'));
+        repl.handle_input(Input::Char('r'));
+        repl.handle_input(Input::Char('i'));
+        repl.handle_input(Input::Char('n'));
+        repl.handle_input(Input::Char('t'));
+
+        let state = repl.get_render_state();
+        // Should find the most recent "print(3)"
+        assert_eq!(state.buffer, "print(3)");
+
+        // Search again (Ctrl+R)
+        repl.handle_input(Input::HistorySearch);
+        let state = repl.get_render_state();
+        // Should find "print(1)"
+        assert_eq!(state.buffer, "print(1)");
+
+        // Search again (fail/stay)
+        repl.handle_input(Input::HistorySearch);
+        let state = repl.get_render_state();
+        // Should stay at "print(1)" or loop?
+        // My impl loops if no more match found? Or stops.
+        // Logic: search backwards from current match_idx.
+        // If match_idx is 0, loop doesn't run.
+        assert_eq!(state.buffer, "print(1)");
+
+        // Accept (Enter)
+        let action = repl.handle_input(Input::Enter);
+        assert_eq!(action, ReplAction::Render); // Just ends search, returns to normal mode with buffer set
+        let state = repl.get_render_state();
+        assert_eq!(state.prompt, ">>> ");
+        assert_eq!(state.buffer, "print(1)");
+    }
+}

--- a/implants/lib/eldritchv2/www/index.html
+++ b/implants/lib/eldritchv2/www/index.html
@@ -18,6 +18,10 @@
             word-wrap: break-word;
             outline: none;
         }
+        #current-line {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
         .prompt {
             color: #569cd6;
             margin-right: 0px; /* Spacing handled by content */
@@ -29,6 +33,16 @@
             background-color: #d4d4d4;
             color: #1e1e1e;
         }
+        /* Visual indicator when not focused */
+        body.not-focused .cursor {
+            background-color: transparent;
+            border: 1px solid #d4d4d4;
+            color: #d4d4d4;
+        }
+        body.not-focused {
+            opacity: 0.8;
+        }
+
         /* Hide the actual input but keep it functional */
         #hidden-input {
             position: absolute;
@@ -57,6 +71,8 @@
 
         // Output handling
         window.repl_print = (s) => {
+            // This is kept for backward compatibility if any direct calls remain,
+            // but the primary output path should now be through handle_key/execute returns.
             printLine(s);
         };
 
@@ -82,8 +98,23 @@
             printLine("Eldritch REPL initialized.\nType code and press Enter.\n");
             render();
 
-            // Focus hidden input
-            document.body.addEventListener('click', () => inputEl.focus());
+            // Focus handling
+            inputEl.addEventListener('focus', () => {
+                document.body.classList.remove('not-focused');
+                render(); // Re-render to update cursor style if needed
+            });
+
+            inputEl.addEventListener('blur', () => {
+                document.body.classList.add('not-focused');
+                render();
+            });
+
+            // Focus hidden input on click anywhere
+            document.body.addEventListener('click', () => {
+                inputEl.focus();
+            });
+
+            // Initial focus
             inputEl.focus();
         }
 
@@ -135,12 +166,17 @@
             // Pass shiftKey to handle_key
             const result = repl.handle_key(key, e.ctrlKey, e.altKey, e.metaKey, e.shiftKey);
 
-            // Handle echo (the command or line accepted)
+            // Handle clear screen
+            if (result.clear) {
+                termEl.innerHTML = '';
+            }
+
+            // Handle echo (the command or line accepted) FIRST
             if (result.echo) {
                 printLine(result.echo);
             }
 
-            // Check output
+            // Then output
             if (result.output) {
                 printLine(result.output);
             }


### PR DESCRIPTION
- Web REPL:
  - Fixed trimmed spaces/tabs in prompt using CSS `white-space: pre-wrap`.
  - Fixed output appearing above prompt by buffering output in `wasm.rs` and returning it via `ExecutionResult`.
  - Added visual focus indicators and ensured focus on load.
- Binary & Web REPL Features:
  - Implemented `Ctrl+L` (Clear Screen) in `repl.rs` and handled in both targets.
  - Implemented `Ctrl+R` (Reverse History Search) in `repl.rs`.
- Fixes:
  - Enabled `std` feature by default in `Cargo.toml` to fix `cargo test` and `build_wasm.sh` issues.
  - Fixed borrow checker error in `search_next`.
- Added tests for new REPL features in `tests/test_repl.rs`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
