### PR TITLE
[CI] Don't fail-fast

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
     env:
       IMIX_SERVER_PUBKEY: "pR56vDJZb9b3BL3ZvCXIvgK0r2vCk7FiZ1RjeEhJVyU="
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,10 @@
+# README
+
+## Quick Start
+
+```sh
+cd vscode/
+npm install -g @vscode/vsce
+vsce package
+code --install-extension eldritch-0.0.3.vsix
+```


### PR DESCRIPTION
Updates our tests CI to not fail fast, allowing all tests to finish (without cancelling tests on other operating systems), improving our flaky detection.