### PR TITLE
Update AGENTS.md with Rust dependency guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Welcome to our repository! Most commands need to be run from the root of the pro
   * Our user interface is located in `tavern/internal/www` and we managed dependencies within that directory using `npm`
 * `implants/` contains Rust code that is deployed to target machines, such as our agent located in `implants/imix`.
 
+## Rust
+
+The majority of our rust codebase is in the `implants/` directory & workspaces. When adding dependencies to crates within this workspace, please add them to the workspace root and have the crate use the workspace dependency, in order to centralize version management. ALWAYS RUN `cargo fmt` WHEN MAKING RUST CHANGES, OR CI WILL FAIL.
+
 ## Golang Tests
 
 To run all Golang tests in our repository, please run `go test ./...` from the project root.


### PR DESCRIPTION
We need jules to run `cargo fmt`... it's killing me