### PR TITLE
Add non-root system-id selection

### DIFF
--- a/implants/lib/host_unique/src/file.rs
+++ b/implants/lib/host_unique/src/file.rs
@@ -17,6 +17,14 @@ pub struct File {
 
 impl File {
     /*
+     * Allow creation of a new file with a custom path
+     */
+    pub fn new_with_file(path: &str) -> Self {
+        Self {
+            path_override: Some(path.to_string()),
+        }
+    }
+    /*
      * Returns a predefined path to the host id file based on the current platform.
      */
     fn get_host_id_path(&self) -> String {
@@ -27,14 +35,16 @@ impl File {
         #[cfg(target_os = "windows")]
         return String::from("C:\\ProgramData\\system-id");
 
-        #[cfg(target_os = "linux")]
-        return String::from("/etc/system-id");
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        ))]
+        return String::from("/var/tmp/system-id");
 
         #[cfg(target_os = "macos")]
         return String::from("/Users/Shared/system-id");
-
-        #[cfg(target_os = "freebsd")]
-        return String::from("/etc/systemd-id");
     }
 }
 

--- a/implants/lib/host_unique/src/lib.rs
+++ b/implants/lib/host_unique/src/lib.rs
@@ -35,5 +35,16 @@ pub fn get_id_with_selectors(selectors: Vec<Box<dyn HostIDSelector>>) -> Uuid {
 // List is evaluated in order and will take the first successful
 // result.
 pub fn defaults() -> Vec<Box<dyn HostIDSelector>> {
-    vec![Box::<Env>::default(), Box::<File>::default()]
+    vec![
+        Box::<Env>::default(),
+        Box::<File>::default(),
+        // Fallback for unix systems / legacy implementation
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        ))]
+        Box::new(File::new_with_file("/etc/system-id")),
+    ]
 }


### PR DESCRIPTION
Let non-root imix beacons use a /var/tmp (persistent on reboot) system-id. Move that system-id to /etc/ whenever a root beacon is run

/kind feature
