### PR TITLE
fix: use MySQL-compatible default for Link expires_at field (#1584)

### DIFF
--- a/tavern/internal/ent/link.go
+++ b/tavern/internal/ent/link.go
@@ -24,7 +24,7 @@ type Link struct {
 	LastModifiedAt time.Time `json:"last_modified_at,omitempty"`
 	// Unique path for accessing the asset via the CDN
 	Path string `json:"path,omitempty"`
-	// Timestamp before which the link is active. Default is epoch 0
+	// Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
 	ExpiresAt time.Time `json:"expires_at,omitempty"`
 	// Number of times this link can be clicked before it becomes inactive
 	DownloadsRemaining int `json:"downloads_remaining,omitempty"`

--- a/tavern/internal/ent/schema/link.go
+++ b/tavern/internal/ent/schema/link.go
@@ -39,11 +39,11 @@ func (Link) Fields() []ent.Field {
 			).
 			Comment("Unique path for accessing the asset via the CDN"),
 		field.Time("expires_at").
-			Default(time.Unix(0, 0)).
+			Default(time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC)).
 			Annotations(
 				entgql.OrderField("EXPIRES_AT"),
 			).
-			Comment("Timestamp before which the link is active. Default is epoch 0"),
+			Comment("Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)"),
 		field.Int("downloads_remaining").
 			Default(0).
 			Min(0).

--- a/tavern/internal/ent/schema/link_test.go
+++ b/tavern/internal/ent/schema/link_test.go
@@ -1,0 +1,110 @@
+package schema_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"realm.pub/tavern/internal/ent"
+	"realm.pub/tavern/internal/ent/enttest"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestCreateLinkWithDownloadsRemainingDefaultExpiresAt tests that creating a link
+// with only downloadsRemaining set (and no expiresAt) results in a MySQL-compatible
+// default expires_at value.
+//
+// This test reproduces GitHub issue #1584:
+// When calling createLink mutation with downloadsRemaining set, the default
+// expires_at value of 1970-01-01 (Unix epoch 0) causes MySQL to fail with:
+// "incorrect date time value '1970-01-01' for column 'expires_at' at row 1"
+//
+// MySQL's minimum DATETIME value is '1000-01-01 00:00:00', but values near the
+// Unix epoch (1970-01-01) can cause issues with timezone conversions that result
+// in negative timestamps, which MySQL rejects.
+func TestCreateLinkWithDownloadsRemainingDefaultExpiresAt(t *testing.T) {
+	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer graph.Close()
+
+	ctx := context.Background()
+
+	// Create an asset first (required for link creation)
+	asset := graph.Asset.Create().
+		SetName("TestAsset").
+		SetContent([]byte("test content")).
+		SaveX(ctx)
+
+	// Create a link with only downloadsRemaining set (simulating the GraphQL mutation)
+	// This is the problematic case from issue #1584
+	downloadsRemaining := 1
+	input := ent.CreateLinkInput{
+		AssetID:            asset.ID,
+		DownloadsRemaining: &downloadsRemaining,
+		// ExpiresAt is intentionally NOT set to trigger the default value
+	}
+
+	link, err := graph.Link.Create().SetInput(input).Save(ctx)
+	require.NoError(t, err, "Link creation should succeed")
+
+	// The bug: the default expires_at is time.Unix(0, 0) which equals 1970-01-01 00:00:00 UTC
+	// This value is rejected by MySQL with the error:
+	// "incorrect date time value '1970-01-01' for column 'expires_at'"
+	//
+	// MySQL minimum valid DATETIME is '1000-01-01 00:00:00'
+	// However, timestamps near epoch 0 (1970-01-01) can cause issues with timezones
+	// that result in negative Unix timestamps, which MySQL rejects.
+	//
+	// The default should NOT be Unix epoch 0 (1970-01-01).
+	epochTime := time.Unix(0, 0)
+	mysqlMinTime := time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// This test will FAIL if the bug is present (default is epoch 0)
+	// and PASS once the fix is applied
+	if link.ExpiresAt.Equal(epochTime) {
+		t.Errorf("BUG DETECTED (GitHub #1584): Default expires_at is Unix epoch 0 (1970-01-01 00:00:00 UTC), "+
+			"which MySQL rejects with error: 'incorrect date time value'. "+
+			"Current value: %v. The default should be a MySQL-compatible value >= %v",
+			link.ExpiresAt.UTC(), mysqlMinTime)
+	}
+
+	// Verify the default expires_at is MySQL-compatible (>= 1000-01-01)
+	assert.True(t, link.ExpiresAt.After(mysqlMinTime) || link.ExpiresAt.Equal(mysqlMinTime),
+		"Default expires_at (%v) must be >= MySQL minimum datetime (%v)",
+		link.ExpiresAt, mysqlMinTime)
+
+	// Verify the link was created with the correct downloadsRemaining
+	assert.Equal(t, 1, link.DownloadsRemaining)
+}
+
+// TestCreateLinkWithExplicitExpiresAt verifies that explicitly setting expiresAt works correctly.
+func TestCreateLinkWithExplicitExpiresAt(t *testing.T) {
+	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer graph.Close()
+
+	ctx := context.Background()
+
+	// Create an asset first
+	asset := graph.Asset.Create().
+		SetName("TestAsset2").
+		SetContent([]byte("test content")).
+		SaveX(ctx)
+
+	// Create a link with explicit expiresAt
+	futureTime := time.Now().Add(24 * time.Hour)
+	downloadsRemaining := 5
+	input := ent.CreateLinkInput{
+		AssetID:            asset.ID,
+		DownloadsRemaining: &downloadsRemaining,
+		ExpiresAt:          &futureTime,
+	}
+
+	link, err := graph.Link.Create().SetInput(input).Save(ctx)
+	require.NoError(t, err)
+
+	// Verify the explicit expiresAt was used
+	assert.WithinDuration(t, futureTime, link.ExpiresAt, time.Second)
+	assert.Equal(t, 5, link.DownloadsRemaining)
+}

--- a/tavern/internal/graphql/generated/root_.generated.go
+++ b/tavern/internal/graphql/generated/root_.generated.go
@@ -3332,7 +3332,7 @@ input CreateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """
@@ -4614,7 +4614,7 @@ type Link implements Node {
   """
   path: String!
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time!
   """
@@ -6614,7 +6614,7 @@ input UpdateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """

--- a/tavern/internal/graphql/mutation.resolvers.go
+++ b/tavern/internal/graphql/mutation.resolvers.go
@@ -270,7 +270,7 @@ func (r *mutationResolver) UpdateLink(ctx context.Context, linkID int, input ent
 // DisableLink is the resolver for the disableLink field.
 func (r *mutationResolver) DisableLink(ctx context.Context, linkID int) (*ent.Link, error) {
 	return r.client.Link.UpdateOneID(linkID).
-		SetExpiresAt(time.Unix(0, 0)).
+		SetExpiresAt(time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC)).
 		SetDownloadsRemaining(0).
 		Save(ctx)
 }

--- a/tavern/internal/graphql/schema.graphql
+++ b/tavern/internal/graphql/schema.graphql
@@ -609,7 +609,7 @@ input CreateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """
@@ -1891,7 +1891,7 @@ type Link implements Node {
   """
   path: String!
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time!
   """
@@ -3891,7 +3891,7 @@ input UpdateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """

--- a/tavern/internal/graphql/schema/ent.graphql
+++ b/tavern/internal/graphql/schema/ent.graphql
@@ -604,7 +604,7 @@ input CreateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """
@@ -1886,7 +1886,7 @@ type Link implements Node {
   """
   path: String!
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time!
   """
@@ -3886,7 +3886,7 @@ input UpdateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """

--- a/tavern/internal/graphql/testdata/mutations/createLink/WithDownloadsRemaining.yml
+++ b/tavern/internal/graphql/testdata/mutations/createLink/WithDownloadsRemaining.yml
@@ -1,0 +1,28 @@
+state: |
+  INSERT INTO `users` (id,oauth_id,photo_url,name,session_token,access_token,is_activated,is_admin)
+    VALUES (5,"test_oauth_id","https://photos.com","test","secretToken","accessToken",true,true);
+  INSERT INTO `assets` (id, name, content, hash, size, created_at, last_modified_at)
+    VALUES (1001, "TestAsset", "test content", "abcdefg123", 12, "2024-01-22 14:51:13", "2024-01-22 14:51:13");
+
+requestor:
+  session_token: secretToken
+query: |
+  mutation CreateLink($input: CreateLinkInput!) {
+    createLink(input: $input) {
+      id
+      downloadsRemaining
+      asset {
+        id
+      }
+    }
+  }
+variables:
+  input:
+    assetID: 1001
+    downloadsRemaining: 1
+expected:
+  createLink:
+    id: "1"
+    downloadsRemaining: 1
+    asset:
+      id: "1001"

--- a/tavern/internal/www/schema.graphql
+++ b/tavern/internal/www/schema.graphql
@@ -609,7 +609,7 @@ input CreateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """
@@ -1891,7 +1891,7 @@ type Link implements Node {
   """
   path: String!
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time!
   """
@@ -3891,7 +3891,7 @@ input UpdateLinkInput {
   """
   path: String
   """
-  Timestamp before which the link is active. Default is epoch 0
+  Timestamp before which the link is active. Default is MySQL minimum datetime (1000-01-01)
   """
   expiresAt: Time
   """


### PR DESCRIPTION
The createLink mutation was failing with MySQL when only downloadsRemaining was set because the default expires_at value of Unix epoch 0 (1970-01-01) is rejected by MySQL with "incorrect date time value '1970-01-01'".

Changes:
- Update Link schema default expires_at from time.Unix(0, 0) to time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC) (MySQL minimum datetime)
- Update DisableLink resolver to use the same MySQL-compatible date
- Add regression tests for createLink with downloadsRemaining
- Add YAML integration test for createLink mutation

Fixes #1584

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
