### PR TITLE
[AI] Update Dependency - uuid

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -134,7 +134,7 @@ tokio-util = { version = "0.7.10", features = ["io"] }
 tonic = { git = "https://github.com/hyperium/tonic.git", rev = "07e4ee1" }
 tonic-build = { git = "https://github.com/hyperium/tonic.git", rev = "c783652" } # Needed git for `.codec_path` in build.rs - previous version of codec setting is really gross. https://github.com/hyperium/tonic/blob/ea8cd3f384e953e177f20a62aa156a75676853f4/examples/build.rs#L44
 trait-variant = "0.1.1"
-uuid = "1.5.0"
+uuid = "1.10.0"
 urlencoding = "2.1.3"
 static_vcruntime = "2.0"
 url = "2.5"


### PR DESCRIPTION
Updated `uuid` dependency in `implants/Cargo.toml` from `1.5.0` to `1.10.0`.

| Module | Package | Old Version | New Version | Status |
| :--- | :--- | :--- | :--- | :--- |
| implants | uuid | 1.5.0 | 1.10.0 | Build Passed |

Note: `Cargo.lock` remained unchanged as `uuid` was already resolved to `1.20.0` (which satisfies both `^1.5.0` and `^1.10.0`). The update in `Cargo.toml` correctly reflects the minimum required version.

---
*PR created automatically by Jules for task [17291947170799336896](https://jules.google.com/task/17291947170799336896) started by @KCarretto*