### PR TITLE
Refactor Portal Mux to use GCP Streaming Pull

### DIFF
--- a/tavern/internal/portals/mux/mux.go
+++ b/tavern/internal/portals/mux/mux.go
@@ -50,7 +50,7 @@ func init() {
 // SubscriptionManager manages active PubSub subscriptions.
 type SubscriptionManager struct {
 	sync.RWMutex
-	active      map[string]*pubsub.Subscription
+	active      map[string]interface{}
 	refs        map[string]int
 	cancelFuncs map[string]context.CancelFunc
 }
@@ -132,7 +132,7 @@ func New(opts ...Option) *Mux {
 			bufferSize: 1024, // Default
 		},
 		subMgr: &SubscriptionManager{
-			active:      make(map[string]*pubsub.Subscription),
+			active:      make(map[string]interface{}),
 			refs:        make(map[string]int),
 			cancelFuncs: make(map[string]context.CancelFunc),
 		},


### PR DESCRIPTION
Refactors the Tavern Portal Mux to use native Google Cloud Pub/Sub Streaming Pull (`Receive`) when running with GCP driver, improving latency over the previous polling implementation.
- Updates `SubscriptionManager` to handle both `gocloud.dev` (generic) and `cloud.google.com/go/pubsub` (native) subscriptions.
- Implements `OpenPortal` and `CreatePortal` logic to use native `Receive` loop with low-latency settings.
- Bridges streaming messages to local subscribers via `dispatchRaw`.
- Ensures proper lifecycle management (context cancellation) and error handling (closing streams on failure).

---
*PR created automatically by Jules for task [5141207035429788701](https://jules.google.com/task/5141207035429788701) started by @KCarretto*