### PR TITLE
Refactor Mux to use GCP Pub/Sub Streaming Pull

### DIFF
--- a/tavern/internal/portals/mux/mux.go
+++ b/tavern/internal/portals/mux/mux.go
@@ -51,6 +51,7 @@ func init() {
 type SubscriptionManager struct {
 	sync.RWMutex
 	active      map[string]*pubsub.Subscription
+	activeGCP   map[string]*gcppubsub.Subscription
 	refs        map[string]int
 	cancelFuncs map[string]context.CancelFunc
 }
@@ -133,6 +134,7 @@ func New(opts ...Option) *Mux {
 		},
 		subMgr: &SubscriptionManager{
 			active:      make(map[string]*pubsub.Subscription),
+			activeGCP:   make(map[string]*gcppubsub.Subscription),
 			refs:        make(map[string]int),
 			cancelFuncs: make(map[string]context.CancelFunc),
 		},


### PR DESCRIPTION
This change refactors the tavern Portal Mux to use Google Cloud Pub/Sub's Streaming Pull (subscription.Receive) instead of the previous unary Pull implementation, which was causing high latency.

Key changes:
- `Mux.OpenPortal` now detects the driver type. If running with GCP driver, it uses `cloud.google.com/go/pubsub` directly to start a `Receive` loop.
- `ReceiveSettings` are tuned for minimum latency (Synchronous=false, MaxOutstandingMessages=-1).
- A new `activeGCP` map in `SubscriptionManager` tracks these native subscriptions alongside the existing `active` map for `gocloud.dev` (used for tests/in-mem).
- `dispatchGCPMsg` helper was added to process native messages.
- If the `Receive` loop fails, a `CLOSE` mote is injected into the local dispatch channel to signal the gRPC stream to close, preventing hanging connections.
- Existing tests using in-memory driver were preserved and verified.

---
*PR created automatically by Jules for task [759347045182909663](https://jules.google.com/task/759347045182909663) started by @KCarretto*