### PR TITLE
Fix flaky E2E REPL test

### DIFF
--- a/tests/e2e/tests/repl.spec.ts
+++ b/tests/e2e/tests/repl.spec.ts
@@ -63,8 +63,10 @@ test('End-to-end reverse shell repl test', async ({ page }) => {
 
   console.log('Sending command');
   // Type something.
-  await page.waitForTimeout(1000); // Wait a bit for connection to be fully established
-  await page.keyboard.type('print("Hello E2E")');
+  // Wait for the prompt to ensure the session is ready
+  await expect(page.locator('.xterm-rows')).toContainText('>>>', { timeout: 20000 });
+  await page.keyboard.type('print("Hello E2E")', { delay: 100 });
+  await page.waitForTimeout(100);
   await page.keyboard.press('Enter');
 
   // Verify output.


### PR DESCRIPTION
Improved the robustness of the "End-to-end reverse shell repl test" in `tests/e2e/tests/repl.spec.ts`. The test was failing sporadically in CI due to race conditions where the input command was typed before the terminal connection was fully established or processed.

Changes:
- Replaced the fixed 1s wait with an assertion waiting for the `>>>` prompt.
- Added `{ delay: 100 }` to `page.keyboard.type` to simulate human typing and ensure characters are not dropped.
- Added a short `waitForTimeout(100)` before pressing Enter to ensure the input buffer is stable.

---
*PR created automatically by Jules for task [8838340678993565307](https://jules.google.com/task/8838340678993565307) started by @KCarretto*