### PR TITLE
Add -count flag to socks5 trace command

### DIFF
--- a/bin/socks5/proxy_test.go
+++ b/bin/socks5/proxy_test.go
@@ -18,7 +18,7 @@ import (
 // MockPortalServer implements the Portal service.
 type MockPortalServer struct {
 	portalpb.UnimplementedPortalServer
-	mu sync.Mutex
+	mu      sync.Mutex
 
 	// For testing, we can hook into received motes
 	onMote func(mote *portalpb.Mote, send func(*portalpb.Mote))
@@ -81,9 +81,7 @@ func BenchmarkProxy(b *testing.B) {
 					sent := 0
 					data := make([]byte, chunkSize)
 					// Fill with some data
-					for i := range data {
-						data[i] = byte(i)
-					}
+					for i := range data { data[i] = byte(i) }
 
 					currentSeq := uint64(0)
 

--- a/bin/socks5/trace.go
+++ b/bin/socks5/trace.go
@@ -56,13 +56,26 @@ func runTrace(ctx context.Context, upstreamAddr string, portalID int64, size int
 
 	var traces []*tracepb.TraceData
 
+	// 1. Open stream once
+	stream, err := client.OpenPortal(ctx)
+	if err != nil {
+		log.Fatalf("Failed to open portal: %v", err)
+	}
+
+	// 2. Register (Send Portal ID)
+	if err := stream.Send(&portalpb.OpenPortalRequest{
+		PortalId: portalID,
+	}); err != nil {
+		log.Fatalf("Failed to send registration message: %v", err)
+	}
+
 	for i := 0; i < count; i++ {
 		// Basic progress for multiple runs
 		if count > 1 {
 			fmt.Fprintf(os.Stderr, "Sending trace %d/%d...\r", i+1, count)
 		}
 
-		td, err := traceOne(ctx, client, portalID, size)
+		td, err := traceOne(ctx, stream, portalID, size)
 		if err != nil {
 			log.Fatalf("\nTrace %d failed: %v", i+1, err)
 		}
@@ -83,22 +96,7 @@ func runTrace(ctx context.Context, upstreamAddr string, portalID int64, size int
 	}
 }
 
-func traceOne(ctx context.Context, client portalpb.PortalClient, portalID int64, size int) (*tracepb.TraceData, error) {
-	// 1. Open a new stream for this trace
-	stream, err := client.OpenPortal(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("open portal: %w", err)
-	}
-	// We want to fully close the stream when done
-	defer stream.CloseSend()
-
-	// 2. Register (Send Portal ID)
-	if err := stream.Send(&portalpb.OpenPortalRequest{
-		PortalId: portalID,
-	}); err != nil {
-		return nil, fmt.Errorf("send registration: %w", err)
-	}
-
+func traceOne(ctx context.Context, stream portalpb.Portal_OpenPortalClient, portalID int64, size int) (*tracepb.TraceData, error) {
 	start := time.Now().UTC().UnixMicro()
 
 	// 3. Send Trace Mote

--- a/bin/socks5/trace_test.go
+++ b/bin/socks5/trace_test.go
@@ -118,6 +118,3 @@ func TestCalculateStats(t *testing.T) {
 		t.Errorf("S2 Max: got %d, want 30", s2.Max)
 	}
 }
-
-// Stub for now to allow compilation of test if I run it before trace.go is updated
-// But I will update trace.go next.


### PR DESCRIPTION
This PR updates the `trace` subcommand in the `bin/socks5` utility to support multiple iterations.
- Adds `-count` flag (default 1).
- Refactors the trace logic to support sequential execution in a loop.
- Adds logic to calculate and display distribution statistics for latencies when multiple traces are run.
- Ensures existing behavior for single trace runs is preserved.
- Validates that stale responses from previous iterations or retries are ignored.
- Adds a unit test for the statistics calculation.

---
*PR created automatically by Jules for task [14459343488200473222](https://jules.google.com/task/14459343488200473222) started by @KCarretto*