### PR TITLE
Add hex() builtin to eldritch-core

### DIFF
--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -10,7 +10,7 @@ permalink: user-guide/eldritch
 🚨 **DEPRECATION WARNING:** Eldritch v1 will soon be deprecated and replaced with v2 🚨
 
 
-Eldritch is a Pythonic red team Domain Specific Language (DSL) based on [starlark](https://github.com/facebookexperimental/starlark-rust). It uses and supports most python syntax and basic functionality such as list comprehension, string operations (`lower()`, `join()`, `replace()`, etc.), and built-in methods (`any()`, `dir()`, `sorted()`, etc.). For more details on the supported functionality not listed here, please consult the [Starlark Spec Reference](https://github.com/bazelbuild/starlark/blob/master/spec.md), but for the most part you can treat this like basic Python with extra red team functionality.
+Eldritch is a Pythonic red team Domain Specific Language (DSL) based on [starlark](https://github.com/facebookexperimental/starlark-rust). It uses and supports most python syntax and basic functionality such as list comprehension, string operations (`lower()`, `join()`, `replace()`, etc.), and built-in methods (`any()`, `dir()`, `hex()`, `sorted()`, etc.). For more details on the supported functionality not listed here, please consult the [Starlark Spec Reference](https://github.com/bazelbuild/starlark/blob/master/spec.md), but for the most part you can treat this like basic Python with extra red team functionality.
 
 Eldritch is a small interpreter that can be embedded into a c2 agent as it is with Golem and Imix.
 By embedding the interpreter into the agent conditional logic can be quickly evaluated without requiring multiple callbacks.

--- a/implants/lib/eldritch/eldritch-core/src/interpreter/builtins/hex.rs
+++ b/implants/lib/eldritch/eldritch-core/src/interpreter/builtins/hex.rs
@@ -1,0 +1,32 @@
+use crate::ast::{Environment, Value};
+use crate::interpreter::introspection::get_type_name;
+use alloc::format;
+use alloc::string::String;
+use alloc::sync::Arc;
+use spin::RwLock;
+
+/// `hex(x)`: Return the hexadecimal representation of an integer.
+///
+/// **Parameters**
+/// - `x` (Int): The integer to convert.
+pub fn builtin_hex(_env: &Arc<RwLock<Environment>>, args: &[Value]) -> Result<Value, String> {
+    if args.len() != 1 {
+        return Err(format!(
+            "hex() takes exactly one argument ({} given)",
+            args.len()
+        ));
+    }
+    match &args[0] {
+        Value::Int(i) => {
+            if *i < 0 {
+                Ok(Value::String(format!("-0x{:x}", i.unsigned_abs())))
+            } else {
+                Ok(Value::String(format!("0x{:x}", i)))
+            }
+        }
+        _ => Err(format!(
+            "hex() argument must be an integer, not '{}'",
+            get_type_name(&args[0])
+        )),
+    }
+}

--- a/implants/lib/eldritch/eldritch-core/src/interpreter/builtins/mod.rs
+++ b/implants/lib/eldritch/eldritch-core/src/interpreter/builtins/mod.rs
@@ -29,6 +29,7 @@ mod all;
 mod any;
 mod dict;
 mod float;
+mod hex;
 mod list;
 mod max;
 mod min;
@@ -74,6 +75,7 @@ pub fn get_all_builtins() -> Vec<(&'static str, BuiltinFn)> {
         ("any", any::builtin_any as BuiltinFn),
         ("all", all::builtin_all as BuiltinFn),
         ("float", float::builtin_float as BuiltinFn),
+        ("hex", hex::builtin_hex as BuiltinFn),
         ("list", list::builtin_list as BuiltinFn),
         ("max", max::builtin_max as BuiltinFn),
         ("min", min::builtin_min as BuiltinFn),

--- a/implants/lib/eldritch/eldritch-core/tests/builtins_hex.rs
+++ b/implants/lib/eldritch/eldritch-core/tests/builtins_hex.rs
@@ -1,0 +1,67 @@
+extern crate alloc;
+extern crate eldritch_core;
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+    use eldritch_core::Interpreter;
+    use eldritch_core::Value;
+
+    #[test]
+    fn test_hex() {
+        let mut interp = Interpreter::new();
+
+        // Valid positive integers
+        let res = interp.interpret("hex(255)");
+        assert_eq!(res.unwrap(), Value::String(String::from("0xff")));
+
+        let res = interp.interpret("hex(42)");
+        assert_eq!(res.unwrap(), Value::String(String::from("0x2a")));
+
+        // Valid negative integers
+        let res = interp.interpret("hex(-42)");
+        assert_eq!(res.unwrap(), Value::String(String::from("-0x2a")));
+
+        // Zero
+        let res = interp.interpret("hex(0)");
+        assert_eq!(res.unwrap(), Value::String(String::from("0x0")));
+
+        // Large integer
+        // 123456789123456789 = 0x1b69b4bacd05f15
+        let res = interp.interpret("hex(123456789123456789)");
+        assert_eq!(
+            res.unwrap(),
+            Value::String(String::from("0x1b69b4bacd05f15"))
+        );
+
+        // Invalid types
+        let res = interp.interpret("hex(1.2)");
+        assert!(res.is_err());
+        assert!(
+            res.unwrap_err()
+                .contains("hex() argument must be an integer")
+        );
+
+        let res = interp.interpret("hex('s')");
+        assert!(res.is_err());
+        assert!(
+            res.unwrap_err()
+                .contains("hex() argument must be an integer")
+        );
+
+        // Argument count
+        let res = interp.interpret("hex()");
+        assert!(res.is_err());
+        assert!(
+            res.unwrap_err()
+                .contains("hex() takes exactly one argument")
+        );
+
+        let res = interp.interpret("hex(1, 2)");
+        assert!(res.is_err());
+        assert!(
+            res.unwrap_err()
+                .contains("hex() takes exactly one argument")
+        );
+    }
+}


### PR DESCRIPTION
Implemented the `hex()` builtin function in `eldritch-core` to convert integers to lowercase hexadecimal strings prefixed with "0x", mimicking Python's `hex()` behavior. Includes comprehensive tests and documentation updates.

---
*PR created automatically by Jules for task [15595911963233056690](https://jules.google.com/task/15595911963233056690) started by @KCarretto*