### PR TITLE
[AI] Update Dependency - github.com/golang-jwt/jwt/v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/99designs/gqlgen v0.17.62
 	github.com/cloudflare/circl v1.5.0
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/tavern/internal/auth/oauth.go
+++ b/tavern/internal/auth/oauth.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 	"realm.pub/tavern/internal/ent"
 	"realm.pub/tavern/internal/ent/user"
@@ -79,7 +79,7 @@ func NewOAuthAuthorizationHandler(cfg oauth2.Config, pubKey ed25519.PublicKey, g
 		}
 
 		// Verify JWT in provided OAuth cookie
-		var claims jwt.StandardClaims
+		var claims jwt.RegisteredClaims
 		stateToken, err := jwt.ParseWithClaims(oauthCookie.Value, &claims, func(stateToken *jwt.Token) (interface{}, error) {
 			// Ensure ed25519 was used
 			if _, ok := stateToken.Method.(*jwt.SigningMethodEd25519); !ok {
@@ -94,7 +94,7 @@ func NewOAuthAuthorizationHandler(cfg oauth2.Config, pubKey ed25519.PublicKey, g
 		}
 
 		// Ensure presented OAuth state matches expected (stored in JWT)
-		if presentedState != claims.Id {
+		if presentedState != claims.ID {
 			http.Error(w, ErrOAuthInvalidState.Error(), http.StatusUnauthorized)
 			return
 		}
@@ -187,12 +187,12 @@ func NewOAuthAuthorizationHandler(cfg oauth2.Config, pubKey ed25519.PublicKey, g
 
 func newOAuthStateCookie(privKey ed25519.PrivateKey, state string) *http.Cookie {
 	expiresAt := time.Now().Add(10 * time.Minute)
-	claims := jwt.StandardClaims{
-		Id:        state,
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: expiresAt.Unix(),
+	claims := jwt.RegisteredClaims{
+		ID:        state,
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
 	}
-	token := jwt.NewWithClaims(&jwt.SigningMethodEd25519{}, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
 	tokenStr, err := token.SignedString(privKey)
 	if err != nil {
 		panic(fmt.Errorf("failed to create oauth-state JWT: %w", err))

--- a/tavern/internal/auth/oauth_test.go
+++ b/tavern/internal/auth/oauth_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,7 +63,7 @@ func TestNewOAuthLoginHandler(t *testing.T) {
 	require.NotNil(t, oauthCookie)
 
 	// Parse JWT
-	var claims jwt.StandardClaims
+	var claims jwt.RegisteredClaims
 	token, err := jwt.ParseWithClaims(oauthCookie.Value, &claims, func(token *jwt.Token) (interface{}, error) {
 		assert.IsType(t, token.Method, &jwt.SigningMethodEd25519{})
 		return pubKey, nil
@@ -72,10 +72,10 @@ func TestNewOAuthLoginHandler(t *testing.T) {
 	assert.True(t, token.Valid)
 
 	// JWT assertions
-	assert.Equal(t, state, claims.Id)
-	assert.GreaterOrEqual(t, claims.IssuedAt, time.Now().Add(-60*time.Second).Unix())
-	assert.Greater(t, claims.ExpiresAt, time.Now().Add(9*time.Minute).Unix())
-	assert.Less(t, claims.ExpiresAt, time.Now().Add(11*time.Minute).Unix())
+	assert.Equal(t, state, claims.ID)
+	assert.GreaterOrEqual(t, claims.IssuedAt.Time.Unix(), time.Now().Add(-60*time.Second).Unix())
+	assert.Greater(t, claims.ExpiresAt.Time.Unix(), time.Now().Add(9*time.Minute).Unix())
+	assert.Less(t, claims.ExpiresAt.Time.Unix(), time.Now().Add(11*time.Minute).Unix())
 }
 
 // TestNewOAuthAuthorizationHandler ensures the OAuth Authorization Handler exhibits expected behaviour
@@ -192,18 +192,18 @@ func getSessionCookie(cookies []*http.Cookie) *http.Cookie {
 func getOAuthAuthorizationRequest(t *testing.T, privKey ed25519.PrivateKey, code string) *http.Request {
 	// Create a JWT
 	expiresAt := time.Now().Add(10 * time.Minute)
-	claims := jwt.StandardClaims{
-		Id:        "ABCDEFG",
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: expiresAt.Unix(),
+	claims := jwt.RegisteredClaims{
+		ID:        "ABCDEFG",
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
 	}
-	token := jwt.NewWithClaims(&jwt.SigningMethodEd25519{}, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
 	tokenStr, err := token.SignedString(privKey)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize", nil)
 	params := url.Values{
-		"state": []string{claims.Id},
+		"state": []string{claims.ID},
 		"code":  []string{code},
 	}
 	req.AddCookie(&http.Cookie{

--- a/tavern/internal/c2/server.go
+++ b/tavern/internal/c2/server.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"realm.pub/tavern/internal/c2/c2pb"

--- a/tavern/internal/c2/server_test.go
+++ b/tavern/internal/c2/server_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"


### PR DESCRIPTION
Update `github.com/golang-jwt/jwt` from v3.2.2+incompatible to v5.3.1.
Fixed breaking changes:
- Updated import paths.
- Replaced `jwt.StandardClaims` with `jwt.RegisteredClaims`.
- Updated `SigningMethodEd25519` to `SigningMethodEdDSA`.
- Updated date handling to use `*jwt.NumericDate`.
- Verified with tests.

| Module | Package | Old Version | New Version | Status |
| :--- | :--- | :--- | :--- | :--- |
| realm.pub | github.com/golang-jwt/jwt | v3.2.2+incompatible | v5.3.1 | Build Passed / Fixed Breaking Change |

---
*PR created automatically by Jules for task [8477144585884578010](https://jules.google.com/task/8477144585884578010) started by @KCarretto*