### PR TITLE
Make PubSub subscriber buffer size configurable

### DIFF
--- a/tavern/config_test.go
+++ b/tavern/config_test.go
@@ -169,3 +169,19 @@ func TestConfigureOAuthFromEnv(t *testing.T) {
 		assert.Equal(t, expectedCfg, cfg.oauth)
 	})
 }
+
+func TestConfigurePubSubFromEnv(t *testing.T) {
+	cleanup := func() {
+		require.NoError(t, os.Unsetenv(EnvPubSubSubscriberMaxMessagesBuffered.Key))
+	}
+	defer cleanup()
+
+	t.Run("Default", func(t *testing.T) {
+		assert.Equal(t, 15625, EnvPubSubSubscriberMaxMessagesBuffered.Int())
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		require.NoError(t, os.Setenv(EnvPubSubSubscriberMaxMessagesBuffered.Key, "9999"))
+		assert.Equal(t, 9999, EnvPubSubSubscriberMaxMessagesBuffered.Int())
+	})
+}

--- a/tavern/internal/portals/mux/mux_test.go
+++ b/tavern/internal/portals/mux/mux_test.go
@@ -191,3 +191,9 @@ func TestMux_OpenPortal(t *testing.T) {
 	assert.False(t, ok)
 	m.subMgr.Unlock()
 }
+
+func TestWithSubscriberBufferSize(t *testing.T) {
+	expected := 12345
+	m := New(WithSubscriberBufferSize(expected))
+	assert.Equal(t, expected, m.subs.bufferSize)
+}


### PR DESCRIPTION
Added `EnvPubSubSubscriberMaxMessagesBuffered` environment variable to configure the PubSub subscriber buffer size in `tavern/config.go`. Updated `NewPortalMux` to use this variable with a default of 15625. Added unit tests in `tavern/config_test.go` and `tavern/internal/portals/mux/mux_test.go`.

---
*PR created automatically by Jules for task [9218092417747451813](https://jules.google.com/task/9218092417747451813) started by @KCarretto*