### PR TITLE
Refactor Mux subscription lifecycle with ref counting

### DIFF
--- a/tavern/internal/portals/mux/mux_open.go
+++ b/tavern/internal/portals/mux/mux_open.go
@@ -2,7 +2,6 @@ package mux
 
 import (
 	"context"
-	"fmt"
 
 	"gocloud.dev/pubsub"
 )
@@ -12,138 +11,21 @@ func (m *Mux) OpenPortal(ctx context.Context, portalID int) (func(), error) {
 	topicOut := m.TopicOut(portalID)
 	subName := m.SubName(topicOut)
 
-	m.subMgr.Lock()
-	// Check Cache
-	if _, ok := m.subMgr.active[subName]; ok {
-		m.subMgr.refs[subName]++
-		m.subMgr.Unlock()
-		return func() {
-			m.subMgr.Lock()
-			m.subMgr.refs[subName]--
-			shouldShutdown := false
-			var s *pubsub.Subscription
-			var cancel context.CancelFunc
-			if m.subMgr.refs[subName] <= 0 {
-				if sub, ok := m.subMgr.active[subName]; ok {
-					s = sub
-					cancel = m.subMgr.cancelFuncs[subName]
-					delete(m.subMgr.active, subName)
-					delete(m.subMgr.refs, subName)
-					delete(m.subMgr.cancelFuncs, subName)
-					shouldShutdown = true
-				}
-			}
-			m.subMgr.Unlock()
-
-			if shouldShutdown {
-				if cancel != nil {
-					cancel()
-				}
-				if s != nil {
-					s.Shutdown(context.Background())
-				}
-			}
-		}, nil
-	}
-	m.subMgr.Unlock()
-
-	// Provisioning
-	// Ensure subscription exists for the OUT topic
-	if err := m.ensureSub(ctx, topicOut, subName); err != nil {
-		return nil, fmt.Errorf("failed to ensure subscription: %w", err)
+	provision := func() error {
+		// Ensure subscription exists for the OUT topic
+		if err := m.ensureSub(ctx, topicOut, subName); err != nil {
+			return err // m.ensureSub already formats error if needed, or we can wrap here. Original wrapped it.
+		}
+		return nil
 	}
 
-	// Connect
-	// Updated SubURL usage
-	subURL := m.SubURL(topicOut, subName)
-	sub, err := m.openSubscription(ctx, subURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open subscription %s: %w", subURL, err)
-	}
-
-	m.subMgr.Lock()
-	// RACE CONDITION CHECK:
-	// Re-check cache in case another goroutine created it while we were provisioning/connecting
-	if existingSub, ok := m.subMgr.active[subName]; ok {
-		// Another routine won the race. Use theirs.
-		m.subMgr.refs[subName]++
-		m.subMgr.Unlock()
-
-		// Close our unused subscription immediately
-		sub.Shutdown(context.Background())
-
-		// Return teardown for the EXISTING subscription
-		return func() {
-			m.subMgr.Lock()
-			m.subMgr.refs[subName]--
-			shouldShutdown := false
-			var s *pubsub.Subscription
-			var cancel context.CancelFunc
-			if m.subMgr.refs[subName] <= 0 {
-				if sub, ok := m.subMgr.active[subName]; ok {
-					s = sub
-					cancel = m.subMgr.cancelFuncs[subName]
-					delete(m.subMgr.active, subName)
-					delete(m.subMgr.refs, subName)
-					delete(m.subMgr.cancelFuncs, subName)
-					shouldShutdown = true
-				}
-			}
-			m.subMgr.Unlock()
-
-			if shouldShutdown {
-				if cancel != nil {
-					cancel()
-				}
-				if existingSub != nil {
-					s.Shutdown(context.Background())
-				}
-			}
-		}, nil
-	}
-
-	// We won the race (or are the first).
-	m.subMgr.active[subName] = sub
-	m.subMgr.refs[subName] = 1
-
-	// Prepare Loop Context
-	ctxLoop, cancelLoop := context.WithCancel(context.Background())
-	m.subMgr.cancelFuncs[subName] = cancelLoop
-
-	m.subMgr.Unlock()
-
-	// Spawn
-	go func() {
-		// No defer cancelLoop() here, controlled by teardown/map
+	startLoop := func(ctxLoop context.Context, sub *pubsub.Subscription) {
 		m.receiveLoop(ctxLoop, topicOut, sub)
-	}()
+	}
 
-	teardown := func() {
-		m.subMgr.Lock()
-		m.subMgr.refs[subName]--
-		shouldShutdown := false
-		var s *pubsub.Subscription
-		var cancel context.CancelFunc
-		if m.subMgr.refs[subName] <= 0 {
-			if sub, ok := m.subMgr.active[subName]; ok {
-				s = sub
-				cancel = m.subMgr.cancelFuncs[subName]
-				delete(m.subMgr.active, subName)
-				delete(m.subMgr.refs, subName)
-				delete(m.subMgr.cancelFuncs, subName)
-				shouldShutdown = true
-			}
-		}
-		m.subMgr.Unlock()
-
-		if shouldShutdown {
-			if cancel != nil {
-				cancel()
-			}
-			if s != nil {
-				s.Shutdown(context.Background())
-			}
-		}
+	teardown, err := m.acquireSubscription(ctx, subName, topicOut, provision, startLoop)
+	if err != nil {
+		return nil, err // acquireSubscription already wraps error
 	}
 
 	return teardown, nil


### PR DESCRIPTION
This PR addresses potential race conditions and inefficient subscription management in the `Mux` component.

Changes:
- Added `acquireSubscription` in `tavern/internal/portals/mux/mux_pubsub.go`: Centralizes subscription acquisition logic, including cache checking, provisioning, connection, race handling, and reference counting.
- Updated `CreatePortal` in `tavern/internal/portals/mux/mux_create.go`: Now uses `acquireSubscription` instead of blindly overwriting existing subscriptions. This prevents premature closure if a subscription is already active (e.g. from a race or collision).
- Updated `OpenPortal` in `tavern/internal/portals/mux/mux_open.go`: Refactored to use `acquireSubscription` for consistency and code reuse.
- Added `TestMux_CreatePortal_RefCounting` in `tavern/internal/portals/mux/mux_test.go`: Verifies that `CreatePortal` correctly initializes reference counts and that teardown respects them (subscription remains active if refs > 0).

This ensures that local subscriptions are robustly managed and shared where appropriate.

---
*PR created automatically by Jules for task [13481624774023790476](https://jules.google.com/task/13481624774023790476) started by @KCarretto*