### PR TITLE
Increase PubSub Subscriber Buffer Size to 32k

### DIFF
--- a/tavern/config.go
+++ b/tavern/config.go
@@ -89,7 +89,7 @@ var (
 	EnvPubSubTopicShellOutput        = EnvString{"PUBSUB_TOPIC_SHELL_OUTPUT", "mem://shell_output"}
 	EnvPubSubSubscriptionShellOutput = EnvString{"PUBSUB_SUBSCRIPTION_SHELL_OUTPUT", "mem://shell_output"}
 
-	EnvPubSubSubscriberMaxMessagesBuffered = EnvInteger{"PUBSUB_SUBSCRIBER_MAX_MESSAGES_BUFFERED", 15625}
+	EnvPubSubSubscriberMaxMessagesBuffered = EnvInteger{"PUBSUB_SUBSCRIBER_MAX_MESSAGES_BUFFERED", 32768}
 
 	// PubSub Configuration Variables
 	EnvGCPPublishDelayThresholdMs                  = EnvInteger{"PUBSUB_GCP_PUBLISH_DELAY_THRESHOLD_MS", 10}

--- a/tavern/config_test.go
+++ b/tavern/config_test.go
@@ -177,7 +177,7 @@ func TestConfigurePubSubFromEnv(t *testing.T) {
 	defer cleanup()
 
 	t.Run("Default", func(t *testing.T) {
-		assert.Equal(t, 15625, EnvPubSubSubscriberMaxMessagesBuffered.Int())
+		assert.Equal(t, 32768, EnvPubSubSubscriberMaxMessagesBuffered.Int())
 	})
 
 	t.Run("Set", func(t *testing.T) {

--- a/tavern/internal/portals/mux/mux.go
+++ b/tavern/internal/portals/mux/mux.go
@@ -110,7 +110,7 @@ func New(opts ...Option) *Mux {
 		serverID: uuid.New().String(),
 		subs: &SubscriberRegistry{
 			subs:       make(map[string][]chan *portalpb.Mote),
-			bufferSize: 15625, // Default
+			bufferSize: 32768, // Default
 		},
 		subMgr: &SubscriptionManager{
 			active:      make(map[string]pubsub.Subscriber),

--- a/tavern/internal/portals/mux/mux_test.go
+++ b/tavern/internal/portals/mux/mux_test.go
@@ -197,3 +197,9 @@ func TestWithSubscriberBufferSize(t *testing.T) {
 	m := New(WithSubscriberBufferSize(expected))
 	assert.Equal(t, expected, m.subs.bufferSize)
 }
+
+func TestDefaultSubscriberBufferSize(t *testing.T) {
+	expected := 32768
+	m := New()
+	assert.Equal(t, expected, m.subs.bufferSize)
+}


### PR DESCRIPTION
Updated the default value of `PUBSUB_SUBSCRIBER_MAX_MESSAGES_BUFFERED` in `tavern/config.go` and the hardcoded default in `tavern/internal/portals/mux/mux.go` to 32768.
Added a new test `TestDefaultSubscriberBufferSize` in `tavern/internal/portals/mux/mux_test.go` and updated `TestConfigurePubSubFromEnv` in `tavern/config_test.go`.

---
*PR created automatically by Jules for task [5789434803782932800](https://jules.google.com/task/5789434803782932800) started by @KCarretto*