### PR TITLE
[AI] Fix Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Want to get involved? [Join our Discord!](https://discord.gg/W4cfwWRNZK)
 
 - **Native GCP Integration:** Leverage the power and scalability of Google Cloud directly within your red team engagements. Realm seamlessly integrates with GCP services, boosting your attack capabilities without reinventing the wheel.
 
-- **Stateless Server Architecture:** While Realm officially supports GCP, you may deploy it's [stateless docker container](https://hub.docker.com/r/spellshift/tavern) to any environment that best fits your needs.
+- **Stateless Server Architecture:** While Realm officially supports GCP, you may deploy its [stateless docker container](https://hub.docker.com/r/spellshift/tavern) to any environment that best fits your needs.
 
 - **Focus on Reliability:** Realm always prioritizes quality over quantity, enabling operators to focus on the engagement instead of spending hours troubleshooting bugs. Extensive testing and rigorous code review ensure unwavering reliability, while an intuitive design and clear documentation keep the learning curve minimal. After reaching a stable `1.0.0` release, Realm will follow [Semantic Versioning](https://semver.org/), ensuring the stability of older deployments.
 

--- a/docs/_docs/admin-guide/tavern.md
+++ b/docs/_docs/admin-guide/tavern.md
@@ -93,7 +93,7 @@ After your certificate has successfully provisioned, it may still take a while (
 |oauth_domain|Only if OAuth is configured|The OAuth Domain that the IDP should redirect to e.g. tavern.mydomain.com (should be the domain you set a CNAME record for while configuring OAuth).|
 |min_scale|No|The minimum number of containers to run, if set to 0 you may see cold boot latency.|
 |max_scale|No|The maximum number of containers to run.|
-|tavern_container_image|No|Override the dafult tavern image with a custom one. You can use spellshift/tavern:edge to use the latest image.| 
+|tavern_container_image|No|Override the default tavern image with a custom one. You can use spellshift/tavern:edge to use the latest image.|
 
 ### Manual Deployment Tips
 
@@ -365,7 +365,7 @@ Running Tavern with the `ENABLE_PPROF` environment variable set will enable perf
 ## Tavern docker image tags explained
 
 Tavern publishes a couple different images.
-- `vX.Y.Z` is a semver style verision string. Each Realm release creates a git tag and container image .
+- `vX.Y.Z` is a semver style version string. Each Realm release creates a git tag and container image .
 - `edge` & `main` are the latest version of tavern in the git repos main branch. These two exist for developers to deploy the latest changes and coerce terraform into deploying upgrades as needed.
 - `sha-<hash>` represents the specific container per a git commit to main. The hash will match the git commit hash as well this can be verified in the docker build workflow logs.
 

--- a/docs/_docs/dev-guide/eldritch.md
+++ b/docs/_docs/dev-guide/eldritch.md
@@ -8,9 +8,9 @@ permalink: dev-guide/eldritch
 
 ## Overview
 
-Eldritch is a Pythonic DSL for Red Team engagements. Eldritch is intended to provide the building-block functionality that operators need, and then operators will compose the provided functionality using Tomes. Creating a function that is too specific could limit it's usefulness to other users.
+Eldritch is a Pythonic DSL for Red Team engagements. Eldritch is intended to provide the building-block functionality that operators need, and then operators will compose the provided functionality using Tomes. Creating a function that is too specific could limit its usefulness to other users.
 
-**For example**: if you want to download a file to a specific location, execute it, and return the functions result this should be chunked into separate `download`, and `execute` functions within Eldritch.
+**For example**: if you want to download a file to a specific location, execute it, and return the function's result this should be chunked into separate `download`, and `execute` functions within Eldritch.
 
 The Eldritch tome could look like this:
 
@@ -42,7 +42,7 @@ Currently Eldritch has the following libraries your function can be bound to:
 * `pivot`: Is used to migrate to identify, and migrate between systems. The pivot library is also responsible for facilitating connectivity within an environment.
 * `process`: Is used to manage running processes on a system.
 * `random` - Used to generate cryptographically secure random values.
-* `regex`: Is used to preform regex operations on strings.
+* `regex`: Is used to perform regex operations on strings.
 * `report`: Is used to report structured data to the caller of the eldritch environment (e.g. to the c2).
 * `sys`: Is used to check system specific configurations and start new processes.
 * `time`: Is used for obtaining and formatting time or adding delays into code.
@@ -91,7 +91,7 @@ pub struct StdFileLibrary;
 
 impl FileLibrary for StdFileLibrary {
     // This Library Binding is what eldritch calls when it evaluates `your_library.function()`
-    // Eldritch function sholud return a type and an error as a string. Here is an example returning a dictiorary and an error string.
+    // Eldritch function should return a type and an error as a string. Here is an example returning a dictionary and an error string.
     fn function(&self, arg1: String, arg2: u8, arg3: UnpackList<String>) -> Result<Vec<BTreeMap<String, Value>>, String> {
         // rust implementation.
         function_impl::function(arg1, arg2, arg3)
@@ -118,7 +118,7 @@ fn helper(argz: String) -> bool {
     // Do helper stuff
 }
 
-pub fn function(path: arg1: String, arg2: u8, arg3: Vec<String>) -> Result<(), String> {
+pub fn function(arg1: String, arg2: u8, arg3: Vec<String>) -> Result<(), String> {
     // Do code stuff
     Ok(true)
 }
@@ -189,7 +189,7 @@ Any methods added to the Eldritch Standard Library should have tests collocated 
 ---
 Limit changes to the implementation file.
 
-OS specific restrictions should be done in the **Eldritch Implementation** you should only have to worry about it in your: `function_impl.rs`.
+OS specific restrictions should be done in the **Eldritch Implementation**. You should only have to worry about it in your: `function_impl.rs`.
 This ensures that all functions are exposed in every version of the Eldritch language.
 To prevent errors and compiler warnings use the `#[cfg(target_os = "windows")]` conditional compiler flag to suppress OS specific code.
 For all non supported OSes return an error with a message explaining which OSes are supported.

--- a/docs/_docs/dev-guide/imix.md
+++ b/docs/_docs/dev-guide/imix.md
@@ -8,7 +8,7 @@ permalink: dev-guide/imix
 
 ## Overview
 
-Imix in the main bot for Realm.
+Imix is the main bot for Realm.
 
 ## Agent protobuf
 
@@ -20,9 +20,9 @@ If you need to update these fields start with the `tavern/internal/c2/proto/c2.p
 
 Once you've finished making your changes apply these changes across the project using `cd /workspaces/realm/ && go generate ./tavern/...`
 
-To generate the associated agent proto's use cargo build in the `implants` directory. This will copy the necessary protos from tavern and perform the code generation.
+To generate the associated agent protos use cargo build in the `implants` directory. This will copy the necessary protos from tavern and perform the code generation.
 
-In addition to config syncronization claimTasks also authorizes the agent to access assets, and report data using a signed JWT per task. This prevents unauthorized users from reading tavern data, or spamming DB writes.
+In addition to config synchronization claimTasks also authorizes the agent to access assets, and report data using a signed JWT per task. This prevents unauthorized users from reading tavern data, or spamming DB writes.
 
 
 ### Adding enums
@@ -51,7 +51,7 @@ And add a new enum definition to `tavern/internal/c2/c2pb/enum_<MESSAGE NAME>_<E
 
 ## Host Selector
 
-The host selector defined in `implants/lib/host_unique` allow imix to reliably identify which host it's running on. This is helpful for operators when creating tasking across multiple beacons as well as when searching for command results. Uniqueness is stored as a UUID4 value.
+The host selector defined in `implants/lib/host_unique` allows imix to reliably identify which host it's running on. This is helpful for operators when creating tasking across multiple beacons as well as when searching for command results. Uniqueness is stored as a UUID4 value.
 
 Out of the box realm comes with two options `File` and `Env` to determine what host it's on.
 

--- a/docs/_docs/dev-guide/introduction.md
+++ b/docs/_docs/dev-guide/introduction.md
@@ -7,7 +7,7 @@ permalink: dev-guide/introduction
 ---
 # Overview
 
-This section of the documentation is meant for new Realm-contributors, and should be read in it's entirety before submitting your first PR. Below you can learn more about our testing & documentation requirements, project layout, and some of the internals of our codebase.
+This section of the documentation is meant for new Realm-contributors, and should be read in its entirety before submitting your first PR. Below you can learn more about our testing & documentation requirements, project layout, and some of the internals of our codebase.
 
 ## Contribution Guidelines
 
@@ -73,7 +73,7 @@ In an attempt to reduce the complexity of merges, we enforce a linear history fo
   * **[tavern/internal](https://github.com/spellshift/realm/tree/main/tavern/internal)** contains various internal packages that makeup Tavern
     * **[tavern/internal/www](https://github.com/spellshift/realm/tree/main/tavern/internal/www)** contains Tavern's UI code
 * **[terraform](https://github.com/spellshift/realm/tree/main/terraform)** contains the Terraform used to deploy a production ready Realm instance. See [Tavern User Guide](https://docs.realm.pub/user-guide/tavern) to learn how to use.
-* **[tests](https://github.com/spellshift/realm/tree/main/tests)** miscellaneous files and example code used for testing. Generally won't be used but required for some niche situations like deadlocking cargo build.
+* **[tests](https://github.com/spellshift/realm/tree/main/tests)** miscellaneous files and example code used for testing. Generally won't be used but is required for some niche situations like deadlocking cargo build.
 * **[vscode](https://github.com/spellshift/realm/tree/main/vscode)** contains our Eldritch VSCode integration source code **(Unmaintained)**
 
 # Where to Start?

--- a/docs/_docs/dev-guide/tavern.md
+++ b/docs/_docs/dev-guide/tavern.md
@@ -20,7 +20,7 @@ Before reading this guide, please check out the [admin guide](/admin-guide/taver
 4. Update `tavern/internal/graphql/gqlgen.yml` to include the ent types in the `autobind:` section (e.g.`- github.com/spellshift/realm/tavern/internal/ent/<NAME>`)
 5. **Optionally** update the `models:` section of `tavern/internal/graphql/gqlgen.yml` to bind any GraphQL enum types to their respective `entgo` generated types (e.g. `github.com/spellshift/realm/tavern/internal/ent/<NAME>.<ENUM_FIELD>`)
 6. Run `go generate ./tavern/...` from the project root
-7. If you added an annotation for a root query field (see above), you will notice auto-generated the `query.resolvers.go` file has been updated with new methods to query your model (e.g. `func (r *queryResolver) <NAME>s ...`)
+7. If you added an annotation for a root query field (see above), you will notice the auto-generated `query.resolvers.go` file has been updated with new methods to query your model (e.g. `func (r *queryResolver) <NAME>s ...`)
     * This must be implemented (e.g. `return r.client.<NAME>.Query().All(ctx)` where NAME is the name of your model)
 
 ### Adding Mutations
@@ -28,7 +28,7 @@ Before reading this guide, please check out the [admin guide](/admin-guide/taver
 1. Update the `mutation.graphql` schema file to include your new mutation and please include it in the section for the model it's mutating if applicable (e.g. createUser should be defined near all the related User mutations)
     * **Note:** The ent.go code generation will create InputTypes that you can use when defining your new mutation in `mutation.graphql`. These types may include: `Create<NAME>Input` or `Update<NAME>Input`. Ensure you've [added the appropriate annotations to your ent schema](https://entgo.io/docs/tutorial-todo-gql#install-and-configure-entgql). If you require custom mutation inputs (e.g. `ClaimTasksInput`) then add them to the `inputs.graphql` file (Golang code will be generated in tavern/internal/graphql/models e.g. `models.ClaimTasksInput`).
 2. Run `go generate ./...`
-3. Implement generated the generated mutation resolver method in `tavern/internal/graphql/mutation.resolvers.go`
+3. Implement the generated mutation resolver method in `tavern/internal/graphql/mutation.resolvers.go`
     * Depending on the mutation you're trying to implement, a one liner such as `return r.client.<NAME>.Create().SetInput(input).Save(ctx)` might be sufficient
 4. Please write a unit test for your new mutation by defining YAML test cases in a new `testdata/mutations` subdirectory with your mutations name (e.g. `tavern/internal/graphql/testdata/mutations/mymutation/SomeTest.yml`)
 
@@ -76,7 +76,7 @@ You may download files from Tavern utilizing the `DownloadFile` gRPC method. Thi
 
 ## Performance Profiling
 
-Tavern supports built in performance monitoring and debugging via the Golang [pprof tool](https://go.dev/blog/pprof) developed by Google. To run tavern with profiling enabled, ensure the `ENABLE_PPROF=1` environment variable is set.
+Tavern supports built-in performance monitoring and debugging via the Golang [pprof tool](https://go.dev/blog/pprof) developed by Google. To run tavern with profiling enabled, ensure the `ENABLE_PPROF=1` environment variable is set.
 
 ### Install Graphviz
 
@@ -143,7 +143,7 @@ The reverse shell system is designed to be distributed. The gRPC server and the 
 
 The reverse shell supports multi-user sessions, where multiple users can be connected to the same shell session. To ensure that messages are delivered in the correct order, the `sessionBuffer` is used. The `sessionBuffer` assigns a unique order key to each user's session, and then it orders the messages based on that key. This ensures that messages from different users are not interleaved, and that they are delivered in the order that they were sent.
 
-If you wish to develop an agent using a different transport method (e.g. DNS), your development will need to include a C2. The role of the C2 is to handle agent communication, and translate the chosen transport method into HTTP(s) requests to Tavern's gRPC API. We recommend reusing the existing protobuf definitions for simplicity and forward compatability. This enables developers to use any transport mechanism with Tavern. If you plan to build a C2 for a common protocol for use with Tavern, consider [submitting a PR](https://github.com/spellshift/realm/pulls).
+If you wish to develop an agent using a different transport method (e.g. DNS), your development will need to include a C2. The role of the C2 is to handle agent communication, and translate the chosen transport method into HTTP(s) requests to Tavern's gRPC API. We recommend reusing the existing protobuf definitions for simplicity and forward compatibility. This enables developers to use any transport mechanism with Tavern. If you plan to build a C2 for a common protocol for use with Tavern, consider [submitting a PR](https://github.com/spellshift/realm/pulls).
 
 ### Agent Loop Lifecycle
 
@@ -233,4 +233,4 @@ func ConfigureOAuthFromEnv(redirectPath string) func(*Config) {
 
 ```
 
-_Keep in mind `/default/` in vault corresponds to the name of the OIDC provider and may be different in your environemnet. You may need to include / create additional scopes to get things like profile pictures and users names from vault into Tavern_
+_Keep in mind `/default/` in vault corresponds to the name of the OIDC provider and may be different in your environment. You may need to include / create additional scopes to get things like profile pictures and users names from vault into Tavern_

--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -180,10 +180,10 @@ not persist across agent reboots.
 `agent.set_callback_uri(new_uri: str) -> None`
 
 The <b>agent.set_callback_uri</b> method takes an string and changes the
-running agent's callback uri to the passed value. This configuration change will
+running agent's callback URI to the passed value. This configuration change will
 not persist across agent reboots. NOTE: please ensure the passed URI path is correct
 for the underlying `Transport` being used, as a URI can take many forms and we make no
-assumptions on `Transport` requirements no gut checks are applied to the passed string.
+assumptions on `Transport` requirements no checks are applied to the passed string.
 
 ---
 
@@ -556,13 +556,13 @@ The <b>http.download</b> method downloads a file at the URI specified in `uri` t
 
 `http.get(uri: str, query_params: Option<Dict<str, str>>, headers: Option<Dict<str, str>>, allow_insecure: Option<bool>) -> str`
 
-The <b>http.get</b> method sends an HTTP GET request to the URI specified in `uri` with the optional query paramters specified in `query_params` and headers specified in `headers`, then return the response body as a string. Note: in order to conform with HTTP2+ all header names are transmuted to lowercase.
+The <b>http.get</b> method sends an HTTP GET request to the URI specified in `uri` with the optional query parameters specified in `query_params` and headers specified in `headers`, then return the response body as a string. Note: in order to conform with HTTP2+ all header names are transmuted to lowercase.
 
 ### http.post
 
 `http.post(uri: str, body: Option<str>, form: Option<Dict<str, str>>, headers: Option<Dict<str, str>>, allow_insecure: Option<bool>) -> str`
 
-The <b>http.post</b> method sends an HTTP POST request to the URI specified in `uri` with the optional request body specified by `body`, form paramters specified in `form`, and headers specified in `headers`, then return the response body as a string. Note: in order to conform with HTTP2+ all header names are transmuted to lowercase. Other Note: if a `body` and a `form` are supplied the value of `body` will be used.
+The <b>http.post</b> method sends an HTTP POST request to the URI specified in `uri` with the optional request body specified by `body`, form parameters specified in `form`, and headers specified in `headers`, then return the response body as a string. Note: in order to conform with HTTP2+ all header names are transmuted to lowercase. Other Note: if a `body` and a `form` are supplied the value of `body` will be used.
 
 ---
 
@@ -640,7 +640,7 @@ Results will be in the format:
 ]
 ```
 
-A ports status can be open, closed, or timeout:
+A port's status can be open, closed, or timeout:
 
 |**State**|**Protocol**| **Meaning**                                          |
 |---------|------------|------------------------------------------------------|
@@ -672,7 +672,7 @@ The <b>pivot.smb_exec</b> method is being proposed to allow users a way to move 
 `pivot.ssh_copy(target: str, port: int, src: str, dst: str, username: str, password: Optional<str>, key: Optional<str>, key_password: Optional<str>, timeout: Optional<int>) -> str`
 
 The <b>pivot.ssh_copy</b> method copies a local file to a remote system.
-ssh_copy will return `"Sucess"` if successful and `"Failed to run handle_ssh_copy: ..."` on failure.
+ssh_copy will return `"Success"` if successful and `"Failed to run handle_ssh_copy: ..."` on failure.
 If the connection is successful but the copy writes a file error will be returned.
 ssh_copy will overwrite the remote file if it exists.
 The file directory the `dst` file exists in must exist in order for ssh_copy to work.
@@ -774,7 +774,7 @@ The <b>process.list</b> method returns a list of dictionaries that describe each
 
 `process.name(pid: int) -> str`
 
-The <b>process.name</b> method returns the name of the process from it's given process id.
+The <b>process.name</b> method returns the name of the process from its given process ID.
 
 ### process.netstat
 
@@ -800,7 +800,7 @@ _Currently only shows LISTENING TCP connections_
 
 ## Random
 
-The random library is designed to enable generation of cryptogrphically secure random vaules. None of these functions will be blocking.
+The random library is designed to enable generation of cryptographically secure random values. None of these functions will be blocking.
 
 ### random.bool
 
@@ -855,7 +855,7 @@ The <b>regex.replace</b> method returns the given haystack with the first captur
 
 ## Report
 
-The report library is designed to enable reporting structured data to Tavern. It's API is still in the active development phase, so **future versions of Eldritch may break tomes that rely on this API**.
+The report library is designed to enable reporting structured data to Tavern. Its API is still in the active development phase, so **future versions of Eldritch may break tomes that rely on this API**.
 
 ### report.file
 
@@ -969,7 +969,7 @@ The <b>sys.get_ip</b> method returns a list of network interfaces as a dictionar
 
 `sys.get_os() -> Dict`
 
-The <b>sys.get_os</b> method returns a dictionary that describes the current systems OS.
+The <b>sys.get_os</b> method returns a dictionary that describes the current system's OS.
 An example is below:
 
 ```json

--- a/docs/_docs/user-guide/getting-started.md
+++ b/docs/_docs/user-guide/getting-started.md
@@ -51,7 +51,7 @@ The warnings you see here indicate that there are settings recommended for produ
 
 ### Tavern (Redirector)
 
-If your adventure requires you to roll for stealth Tavern's redirectors have your back! Redirectors allow you to forward traffic from multiple different IPs, Domains, and even protocols. Including GRPC, HTTP1, and DNS. Out of the box tavern c2 only uses grpc but by adding a redirector you unlock any any supported protocol.
+If your adventure requires you to roll for stealth, Tavern's redirectors have your back! Redirectors allow you to forward traffic from multiple different IPs, Domains, and even protocols. Including GRPC, HTTP1, and DNS. Out of the box tavern c2 only uses grpc but by adding a redirector you unlock any supported protocol.
 
 ```bash
 git clone https://github.com/spellshift/realm.git
@@ -87,7 +87,7 @@ These configurations can be controlled via Environment Variables at `imix` compi
 
 ### Quests
 
-Now it's time to provide our [Beacon](/user-guide/terminology#beacon) it's first [Task](/user-guide/terminology#task). We do this, by creating a [Quest](/user-guide/terminology#quest) in the UI, which represents a collection of [Tasks](/user-guide/terminology#task) across one or more [Hosts](/user-guide/terminology#host). Let's open our UI, which should be available at [http://127.0.0.1:8000/](http://127.0.0.1:8000/).
+Now it's time to provide our [Beacon](/user-guide/terminology#beacon) its first [Task](/user-guide/terminology#task). We do this, by creating a [Quest](/user-guide/terminology#quest) in the UI, which represents a collection of [Tasks](/user-guide/terminology#task) across one or more [Hosts](/user-guide/terminology#host). Let's open our UI, which should be available at [http://127.0.0.1:8000/](http://127.0.0.1:8000/).
 
 #### Beacon Selection
 
@@ -115,7 +115,7 @@ Lastly, we'll be greeted with a prompt displaying a summary of the [Quest](/user
 
 #### Results
 
-Now, in your `imix` logs you'll see that when it calls back, it will obtain the [Tome](/user-guide/terminology#tome) from Tavern and evaluate it. On it's next callback, it will report the results.
+Now, in your `imix` logs you'll see that when it calls back, it will obtain the [Tome](/user-guide/terminology#tome) from Tavern and evaluate it. On its next callback, it will report the results.
 
 ![imix-tome-eval](/assets/img/user-guide/getting-started/imix-tome-eval.png)
 

--- a/docs/_docs/user-guide/golem.md
+++ b/docs/_docs/user-guide/golem.md
@@ -8,7 +8,7 @@ permalink: user-guide/golem
 ## What is Golem
 
 Golem is the standalone interpreter for Eldritch.
-This program exists to help users get experience with the Eldritch language as well as a jumping off point if you're interested in implementing your own program using the Eldritch language. Additionally, consult our [Tomes](/user-guide/tomes) documentation for information about packaging [Eldritch](/user-guide/terminology#eldritch) code for use with [Imix](/user-guide/imix) and Tavern.
+This program exists to help users get experience with the Eldritch language as well as a jumping-off point if you're interested in implementing your own program using the Eldritch language. Additionally, consult our [Tomes](/user-guide/tomes) documentation for information about packaging [Eldritch](/user-guide/terminology#eldritch) code for use with [Imix](/user-guide/imix) and Tavern.
 
 Golem can also be used operationally as an alternative to a system native shell.
 You can leverage the power of Eldritch with minimal exposure in the system process tree.
@@ -20,7 +20,7 @@ git clone git@github.com:spellshift/realm.git
 cd realm/implants/golem
 git checkout -b latest $(git tag | tail -1) # Checkout the latest stable releases
 
-# Launch and interactive REPL
+# Launch an interactive REPL
 cargo run -- -i
 
 # Or run a tome on disk
@@ -47,7 +47,7 @@ Copy an existing tome and rename it to your desired name.
 [./tomes]$ cp -r ./file_list ./new_tome
 ```
 
-This will setup the boiler plate.
+This will setup the boilerplate.
 A tome file structure should look like this:
 
 ```
@@ -113,7 +113,7 @@ def file_list(path):
 # Call our tomes function.
 file_list(input_params['path'])
 # `input_params` is a dictionary that's implicitly passed into the Eldritch runtime.
-# The key value pairs in input_params is defined by the users answers to the paramdefs in the UI.
+# The key value pairs in input_params is defined by the user's answers to the paramdefs in the UI.
 # For example if you specify `name: path` in your `metadata.yml` file the UI will ask the user for
 # a path and then populate the `path` key in `input_params` when the tome runs.
 # Input params is unique to each task so setting a var in one task won't affect others.
@@ -126,7 +126,7 @@ print("\n")
 Tomes are designed to accomplish specific workflows.
 Some small tomes have been created to accomplish basic sysadmin tasks like reading, writing files, checking processes etc.
 Ideally though if you have a specific workflow you'll define it as a tome.
-We want to avoid queueing multiple quests to accomplish a workflow.
+We want to avoid queuing multiple quests to accomplish a workflow.
 
 ### Testing your tome
 
@@ -178,8 +178,8 @@ main()
 
 ```python
 def decrypt(payload_bytes):
-    let res = []
-    for byte in in payload_bytes:
+    res = []
+    for byte in payload_bytes:
         res.push(byte ^ 6)
     return res
 
@@ -187,7 +187,7 @@ def main():
     if is_windows():
         for proc in process.list():
             if "svchost.exe" in proc['name']:
-                let enc_bytes = assets.read_bytes("imix.dll")
+                enc_bytes = assets.read_bytes("imix.dll")
                 sys.dll_reflect(decrypt(enc_bytes), proc['pid'], 'imix_main')
                 return
 

--- a/docs/_docs/user-guide/imix.md
+++ b/docs/_docs/user-guide/imix.md
@@ -7,7 +7,7 @@ permalink: user-guide/imix
 ---
 ## Imix
 
-Imix is an offensive security implant designed for stealthy communication and adversary emulation. It functions as a [Beacon](/user-guide/terminology#beacon), receiving [Eldritch](/user-guide/terminology#eldritch) packages called [Tomes](/user-guide/terminology#tome) from a central server ([Tavern](/admin-guide/tavern)) and evaluating them on the host system. It currently supports [gRPC over HTTP(s)](https://grpc.io/) as it's primary communication mechanism, but can be extended to support additional transport channels (see the [developer guide](/dev-guide/tavern#agent-development) for more info).
+Imix is an offensive security implant designed for stealthy communication and adversary emulation. It functions as a [Beacon](/user-guide/terminology#beacon), receiving [Eldritch](/user-guide/terminology#eldritch) packages called [Tomes](/user-guide/terminology#tome) from a central server ([Tavern](/admin-guide/tavern)) and evaluating them on the host system. It currently supports [gRPC over HTTP(s)](https://grpc.io/) as its primary communication mechanism, but can be extended to support additional transport channels (see the [developer guide](/dev-guide/tavern#agent-development) for more info).
 
 ## Configuration
 
@@ -42,9 +42,9 @@ Imix has run-time configuration, that may be specified using environment variabl
 **We strongly recommend building agents inside the provided devcontainer `.devcontainer`**
 Building in the dev container limits variables that might cause issues and is the most tested way to compile.
 
-**Imix requires a server public key so it can encrypt messages to and from the server check the server stauts page `http://example.com/status` or logs for `level=INFO msg="public key: <SERVER_PUBKEY_B64>"`. This base64 encoded string should be passed to the agent using the environment variable `IMIX_SERVER_PUBKEY`**
+**Imix requires a server public key so it can encrypt messages to and from the server check the server status page `http://example.com/status` or logs for `level=INFO msg="public key: <SERVER_PUBKEY_B64>"`. This base64 encoded string should be passed to the agent using the environment variable `IMIX_SERVER_PUBKEY`**
 
-**🚨 Note:** You must cd into the imx directory `implants/imix/` not `implants/` in order to build the agent.
+**🚨 Note:** You must cd into the imix directory `implants/imix/` not `implants/` in order to build the agent.
 
 ## Setting encryption key
 
@@ -78,7 +78,7 @@ cargo build --release --bin imix --target=x86_64-unknown-linux-musl
 #### Setup
 Setup the MacOS SDK in a place that docker can access.
 Rancher desktop doesn't allow you to mount folders besides ~/ and /tmp/
-therefore we need to copy it into an accesible location.
+therefore we need to copy it into an accessible location.
 Run the following on your MacOS host:
 
 ```bash
@@ -225,7 +225,7 @@ This feature is currently under active development, and may change. We'll do our
 
 ## Functionality
 
-Imix derives all it's functionality from the eldritch language.
+Imix derives all its functionality from the eldritch language.
 See the [Eldritch User Guide](/user-guide/eldritch) for more information.
 
 ## Task management
@@ -236,7 +236,7 @@ Every callback interval imix will query each active thread for new output and re
 
 ## Identifying unique hosts
 
-Imix communicates which host it's on to Tavern enabling operators to reliably perform per host actions. The default way that imix does this is through a file on disk. We recognize that this may be un-ideal for many situations so we've also provided an environment override and made it easy for admins managing a realm deployment to change how the bot determines uniqueness.
+Imix communicates which host it's on to Tavern enabling operators to reliably perform per host actions. The default way that imix does this is through a file on disk. We recognize that this may be not ideal for many situations so we've also provided an environment override and made it easy for admins managing a realm deployment to change how the bot determines uniqueness.
 
 Imix uses the `host_unique` library under `implants/lib/host_unique` to determine which host it's on. The `id` function will fail over all available options returning the first successful ID. If a method is unable to determine the uniqueness of a host it should return `None`.
 
@@ -251,4 +251,4 @@ If you cannot use the `File` selector we highly recommend manually setting the `
 For Windows hosts, a `Registry` selector is available, but must be enabled before compilation. See the [imix dev guide](/dev-guide/imix#host-selector) on how to enable it.
 
 If all uniqueness selectors fail imix will randomly generate a UUID to avoid crashing.
-This isn't ideal as in the UI each new beacon will appear as thought it were on a new host.
+This isn't ideal as in the UI each new beacon will appear as though it were on a new host.

--- a/docs/_docs/user-guide/terminology.md
+++ b/docs/_docs/user-guide/terminology.md
@@ -28,7 +28,7 @@ Hosts are in-scope systems for the current engagement. A host can have multiple 
 
 ### Quest
 
-Quests enable multi-beacon managment by taking a list of beacons and executing a tome with customized parameters against them. A quest is made up of tasks assocaited with a single beacon.
+Quests enable multi-beacon managment by taking a list of beacons and executing a tome with customized parameters against them. A quest is made up of tasks associated with a single beacon.
 
 ### Task
 
@@ -36,7 +36,7 @@ A task is a single instance of a tome plus its parameters executed against a sin
 
 ### Eldritch
 
-Eldritch is our Pythonic Domain Specific Language (DSL), which can be used to progammatically define red team operations. Many of the language's built-in features do not rely on system binaries. For more information, please see the [Eldritch section](/user-guide/eldritch) of the documentation.
+Eldritch is our Pythonic Domain Specific Language (DSL), which can be used to programmatically define red team operations. Many of the language's built-in features do not rely on system binaries. For more information, please see the [Eldritch section](/user-guide/eldritch) of the documentation.
 
 ### Tome
 

--- a/docs/_docs/user-guide/tomes.md
+++ b/docs/_docs/user-guide/tomes.md
@@ -15,7 +15,7 @@ A [Tome](/user-guide/terminology#tome) has a well-defined structure consisting o
 
 1. `metadata.yml`: This file serves as the [Tome's](/user-guide/terminology#tome) blueprint, containing essential information in YAML format. More information about this file can be found below in the [Tome Metadata section.](/user-guide/tomes#tome-metadata)
 
-2. `main.eldritch`: This file is where the magic happens. It contains the [Eldritch](/user-guide/terminology#eldritch) code evaluated by the [Tome](/user-guide/terminology#tome). Testing your code with [Golem](/user-guide/golem) before running it in production is highly recommended, since it enables signficantly faster developer velocity.
+2. `main.eldritch`: This file is where the magic happens. It contains the [Eldritch](/user-guide/terminology#eldritch) code evaluated by the [Tome](/user-guide/terminology#tome). Testing your code with [Golem](/user-guide/golem) before running it in production is highly recommended, since it enables significantly faster developer velocity.
 
 3. `assets/` (optional): [Tomes](/user-guide/terminology#tome) have the capability to leverage additional resources stored externally. These assets, which may include data files, configuration settings, or other tools, are fetched using the implant's callback protocol (e.g. `gRPC`) using the [Eldritch Assets API](/user-guide/eldritch#assets). More information about these files can be found below in the [Tome Assets section.](/user-guide/tomes#tome-assets)
 
@@ -26,7 +26,7 @@ The `metadata.yml` file specifies key information about a [Tome](/user-guide/ter
 | Name | Description | Required |
 |------|-------------|----------|
 | `name` | Display name of your [Tome](/user-guide/terminology#tome). | Yes |
-| `description` | Provide a helpful description of functionality, for user's of your [Tome](/user-guide/terminology#tome). | Yes |
+| `description` | Provide a helpful description of functionality, for users of your [Tome](/user-guide/terminology#tome). | Yes |
 | `author` | Your name/handle, so you can get credit for your amazing work! | Yes |
 | `support_model` | The type of support offered by this tome `FIRST_PARTY` (from realm developers) or `COMMUNITY` | Yes |
 | `tactic` | The relevant [MITRE ATT&CK tactic](https://attack.mitre.org/tactics/enterprise/) that best describes this [Tome](/user-guide/terminology#tome). Possible values include: `UNSPECIFIED`, `RECON`, `RESOURCE_DEVELOPMENT`, `INITIAL_ACCESS`, `EXECUTION`, `PERSISTENCE`, `PRIVILEGE_ESCALATION`, `DEFENSE_EVASION`, `CREDENTIAL_ACCESS`, `DISCOVERY`, `LATERAL_MOVEMENT`, `COLLECTION`,`COMMAND_AND_CONTROL`,`EXFILTRATION`, `IMPACT`. | Yes |
@@ -150,7 +150,7 @@ If you test off target you can leverage native functions like [`sys.get_os`](/us
 
 ### Example
 
-Copy and run an asset in a safe and idempotant way
+Copy and run an asset in a safe and idempotent way
 
 ```python
 IMPLANT_ASSET_PATH = "tome_name/assets/implant"
@@ -272,7 +272,7 @@ main(input_params['DEST_FILE_PATH'])
 
 ### Fail early
 Before modifying anything on Target or loading assets validate that the tome you're building will run as expected.
-This avoids artifacts being left on disk if something fails and also provides verbose feedback in the event of an error to reduce trouble shooting time.
+This avoids artifacts being left on disk if something fails and also provides verbose feedback in the event of an error to reduce troubleshooting time.
 
 Common things to validate:
 - Operating systems - all tomes are cross platform so it's up to the tome developer to fail if run on an unsupported OS
@@ -310,7 +310,7 @@ res = sys.shell(f"{shell_client} 127.0.0.1 id")
 
 
 ### Idempotence
-In many situations especially when deploying persistance you'll want to ensure that running a tome twice won't cause issues.
+In many situations especially when deploying persistence you'll want to ensure that running a tome twice won't cause issues.
 The best way to handle this is to when possible check the current state of the resource you're about to modify.
 
 This often takes the shape of running validation before and after taking an action.


### PR DESCRIPTION
This PR addresses various spelling errors and typos found throughout the repository's documentation files (*.md).

No code changes were made, so no tests were run, as per instructions.

Fixed typos include:
- `dafult` -> `default`
- `verision` -> `version`
- `dictiorary` -> `dictionary`
- `paramters` -> `parameters`
- `signficantly` -> `significantly`
- `idempotant` -> `idempotent`
- `trouble shooting` -> `troubleshooting`
- `persistance` -> `persistence`
- `stauts` -> `status`
- `accesible` -> `accessible`
- `environemnet` -> `environment`
- `compatability` -> `compatibility`
- Grammar fix: `it's` vs `its` in multiple places.
- Grammar fix: `users` vs `user's`.
- Grammar fix: `Host selector ... allow` -> `Host selector ... allows`.
- Formatting fix in Eldritch code examples (removing `let`, fixing `in in`).

---
*PR created automatically by Jules for task [14350525175584834919](https://jules.google.com/task/14350525175584834919) started by @KCarretto*