### PR TITLE
[AI] Expand Test Coverage - eldritch-core

### DIFF
--- a/implants/lib/eldritch/eldritch-core/tests/io_builtins.rs
+++ b/implants/lib/eldritch/eldritch-core/tests/io_builtins.rs
@@ -1,0 +1,95 @@
+extern crate alloc;
+
+use alloc::sync::Arc;
+use eldritch_core::{BufferPrinter, Interpreter};
+
+fn check_output(code: &str, expected_out: &str, expected_err: &str) {
+    let printer = Arc::new(BufferPrinter::new());
+    let mut interp = Interpreter::new_with_printer(printer.clone());
+
+    // Simple indentation stripping
+    let code_trimmed = code
+        .lines()
+        .map(|l| l.trim())
+        .collect::<alloc::vec::Vec<_>>()
+        .join("\n");
+
+    if let Err(e) = interp.interpret(&code_trimmed) {
+        panic!("Interpretation failed for code:\n{}\nError: {}", code, e);
+    }
+
+    let out = printer.read_out();
+    let err = printer.read_err();
+
+    assert_eq!(out.trim(), expected_out.trim(), "Stdout mismatch");
+    assert_eq!(err.trim(), expected_err.trim(), "Stderr mismatch");
+}
+
+#[test]
+fn test_print_basic() {
+    let code = r#"
+    print("hello")
+    print("world")
+    "#;
+    check_output(code, "hello\nworld", "");
+}
+
+#[test]
+fn test_print_multiple_args() {
+    let code = r#"
+    print("hello", "world", 123)
+    "#;
+    // print joins args with space
+    check_output(code, "hello world 123", "");
+}
+
+#[test]
+fn test_eprint_basic() {
+    let code = r#"
+    eprint("error message")
+    "#;
+    check_output(code, "", "error message");
+}
+
+#[test]
+fn test_eprint_mixed() {
+    let code = r#"
+    print("standard")
+    eprint("error")
+    print("output")
+    "#;
+    check_output(code, "standard\noutput", "error");
+}
+
+#[test]
+fn test_pprint_basic() {
+    let code = r#"
+    d = {"a": 1}
+    pprint(d)
+    "#;
+    // Simple indentation stripping
+    let code_trimmed = code
+        .lines()
+        .map(|l| l.trim())
+        .collect::<alloc::vec::Vec<_>>()
+        .join("\n");
+
+    // pprint output format depends on implementation, but typically valid JSON/Python dict syntax
+    // We expect it to be printed to stdout
+    let printer = Arc::new(BufferPrinter::new());
+    let mut interp = Interpreter::new_with_printer(printer.clone());
+    interp.interpret(&code_trimmed).unwrap();
+
+    let out = printer.read_out();
+    assert!(out.contains("\"a\": 1") || out.contains("'a': 1"));
+}
+
+#[test]
+fn test_print_types() {
+    let code = r#"
+    print(None)
+    print(True)
+    print([1, 2])
+    "#;
+    check_output(code, "None\nTrue\n[1, 2]", "");
+}

--- a/implants/lib/eldritch/eldritch-core/tests/lexer_edges.rs
+++ b/implants/lib/eldritch/eldritch-core/tests/lexer_edges.rs
@@ -215,6 +215,51 @@ fn test_string_unterminated() {
 }
 
 #[test]
+fn test_number_trailing_dot_limitation() {
+    // Current limitation: "1." is lexed as Integer(1) followed by Dot.
+    // In many languages this is a float (1.0).
+    // This test asserts the *current* behavior to detect if it changes.
+    let input = "1.";
+    let tokens = lex(input);
+    let expected = vec![
+        TokenKind::Integer(1),
+        TokenKind::Dot,
+        TokenKind::Newline,
+        TokenKind::Eof,
+    ];
+    assert_eq!(tokens, expected);
+}
+
+#[test]
+fn test_scientific_notation_unsupported() {
+    // Current limitation: Scientific notation is not supported.
+    // "1e10" is lexed as Integer(1) followed by Identifier(e10).
+    let input = "1e10";
+    let tokens = lex(input);
+    let expected = vec![
+        TokenKind::Integer(1),
+        TokenKind::Identifier(String::from("e10")),
+        TokenKind::Newline,
+        TokenKind::Eof,
+    ];
+    assert_eq!(tokens, expected);
+}
+
+#[test]
+fn test_scientific_notation_float_unsupported() {
+    // "1.5e10" -> Float(1.5), Identifier(e10)
+    let input = "1.5e10";
+    let tokens = lex(input);
+    let expected = vec![
+        TokenKind::Float(1.5),
+        TokenKind::Identifier(String::from("e10")),
+        TokenKind::Newline,
+        TokenKind::Eof,
+    ];
+    assert_eq!(tokens, expected);
+}
+
+#[test]
 fn test_string_newline_error() {
     let input = "\"line1\nline2\"";
     let tokens = lex(input);


### PR DESCRIPTION
This PR expands test coverage for `eldritch-core` by adding:
1.  `io_builtins.rs`: New tests for `print`, `eprint`, and `pprint` builtins, ensuring output is correctly captured.
2.  `lexer_edges.rs`: Additional regression tests documenting known limitations of the lexer (handling of `1.` and scientific notation), protecting against unintended behavioral changes.

Tests were verified using `cargo test` in `implants/lib/eldritch/eldritch-core`.

---
*PR created automatically by Jules for task [9262577693529911191](https://jules.google.com/task/9262577693529911191) started by @KCarretto*