### PR TITLE
[AI] Fix Typos

### DIFF
--- a/implants/lib/eldritch/stdlib/eldritch-libpivot/src/std/ncat_impl.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libpivot/src/std/ncat_impl.rs
@@ -46,7 +46,7 @@ async fn handle_ncat(address: String, port: i32, data: String, protocol: String)
             .send_to(data.as_bytes(), address_and_port.clone())
             .await?;
 
-        // Recieve any response from remote host
+        // Receive any response from remote host
         let mut response_buffer = [0; 1024];
         let (_bytes_copied, _addr) = sock.recv_from(&mut response_buffer).await?;
 

--- a/tavern/cli/auth/auth.go
+++ b/tavern/cli/auth/auth.go
@@ -148,6 +148,6 @@ func newTokenHandler(tokenCh chan<- Token, errCh chan<- error) http.HandlerFunc 
 		}
 
 		tokenCh <- Token(token)
-		io.WriteString(w, "Succesfully Authenticated!")
+		io.WriteString(w, "Successfully Authenticated!")
 	})
 }


### PR DESCRIPTION
This PR fixes two typos found in the codebase.
One in a Rust file (comment) and one in a Go file (string literal).
Tests were run and passed for both changes.

---
*PR created automatically by Jules for task [6071058989433864337](https://jules.google.com/task/6071058989433864337) started by @KCarretto*