### PR TITLE
Refactor cryptocodec for high throughput and reduced allocations

### DIFF
--- a/benchmark_baseline.txt
+++ b/benchmark_baseline.txt
@@ -1,0 +1,15 @@
+2026/02/05 05:25:00 ERROR failed to create public key crypto/ecdh: invalid public key
+2026/02/05 05:25:00 ERROR input bytes to short 1 expected at least 32
+2026/02/05 05:25:00 ERROR failed to get shared secret crypto/ecdh: bad X25519 remote ECDH input: low order point
+2026/02/05 05:25:00 ERROR failed to create xchacha key chacha20poly1305: bad key length
+2026/02/05 05:25:00 ERROR public key not found for id: 0
+goos: linux
+goarch: amd64
+pkg: realm.pub/tavern/internal/cryptocodec
+cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
+BenchmarkEncrypt-4        	   13266	     91523 ns/op	  11.19 MB/s	    4408 B/op	      10 allocs/op
+BenchmarkEncryptLarge-4   	     291	   3832558 ns/op	 273.60 MB/s	 2115679 B/op	      11 allocs/op
+BenchmarkDecrypt-4        	   13568	     88719 ns/op	  11.54 MB/s	    3128 B/op	       9 allocs/op
+BenchmarkDecryptLarge-4   	     544	   2068380 ns/op	 506.96 MB/s	 1050696 B/op	       9 allocs/op
+PASS
+ok  	realm.pub/tavern/internal/cryptocodec	7.184s

--- a/benchmark_final.txt
+++ b/benchmark_final.txt
@@ -1,0 +1,13 @@
+2026/02/05 05:29:23 ERROR input bytes to short 1 expected at least 32
+2026/02/05 05:29:23 ERROR failed to get aead failed to get shared secret crypto/ecdh: bad X25519 remote ECDH input: low order point
+2026/02/05 05:29:23 ERROR public key not found for id: 0
+goos: linux
+goarch: amd64
+pkg: realm.pub/tavern/internal/cryptocodec
+cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
+BenchmarkEncrypt-4        	   84398	     14302 ns/op	  71.60 MB/s	    3128 B/op	       6 allocs/op
+BenchmarkEncryptLarge-4   	     661	   1779365 ns/op	 589.30 MB/s	 1058767 B/op	       6 allocs/op
+BenchmarkDecrypt-4        	   69344	     17025 ns/op	  60.15 MB/s	    1984 B/op	       5 allocs/op
+BenchmarkDecryptLarge-4   	    1530	    742227 ns/op	1412.74 MB/s	    2675 B/op	       5 allocs/op
+PASS
+ok  	realm.pub/tavern/internal/cryptocodec	18.716s

--- a/tavern/internal/cryptocodec/cryptocodec_bench_test.go
+++ b/tavern/internal/cryptocodec/cryptocodec_bench_test.go
@@ -41,6 +41,39 @@ func BenchmarkEncrypt(b *testing.B) {
 	}
 }
 
+func BenchmarkEncryptLarge(b *testing.B) {
+	// Setup keys
+	serverPrivKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(b, err)
+
+	clientPrivKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(b, err)
+	clientPubKey := clientPrivKey.PublicKey().Bytes()
+
+	svc := NewCryptoSvc(serverPrivKey)
+
+	// Register current goroutine ID with client public key
+	trace, err := goAllIds()
+	require.NoError(b, err)
+	session_pub_keys.Store(trace.Id, clientPubKey)
+
+	// 1MB payload
+	payload := make([]byte, 1024*1024)
+	_, err = rand.Read(payload)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+
+	for i := 0; i < b.N; i++ {
+		encrypted := svc.Encrypt(payload)
+		if len(encrypted) == 0 {
+			b.Fatal("Encrypt returned empty slice")
+		}
+	}
+}
+
 func BenchmarkDecrypt(b *testing.B) {
 	// Setup keys
 	serverPrivKey, err := ecdh.X25519().GenerateKey(rand.Reader)
@@ -78,8 +111,70 @@ func BenchmarkDecrypt(b *testing.B) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(plaintext)))
 
+	// Decrypt modifies input in-place, so we must copy it for each iteration
+	// to ensure valid ciphertext.
+	// We stop timer during copy to measure only Decrypt performance.
+	input := make([]byte, len(payload))
+
 	for i := 0; i < b.N; i++ {
-		decrypted, _ := svc.Decrypt(payload)
+		b.StopTimer()
+		copy(input, payload)
+		b.StartTimer()
+
+		decrypted, _ := svc.Decrypt(input)
+		if len(decrypted) == 0 {
+			b.Fatal("Decrypt returned empty slice")
+		}
+	}
+}
+
+func BenchmarkDecryptLarge(b *testing.B) {
+	// Setup keys
+	serverPrivKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(b, err)
+
+	clientPrivKey, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(b, err)
+	clientPubKey := clientPrivKey.PublicKey().Bytes()
+
+	// Compute shared secret manually to encrypt
+	sharedSecret, err := clientPrivKey.ECDH(serverPrivKey.PublicKey())
+	require.NoError(b, err)
+
+	// Create AEAD
+	aead, err := chacha20poly1305.NewX(sharedSecret)
+	require.NoError(b, err)
+
+	// 1MB payload
+	plaintext := make([]byte, 1024*1024)
+	_, err = rand.Read(plaintext)
+	require.NoError(b, err)
+
+	nonce := make([]byte, aead.NonceSize())
+	_, err = rand.Read(nonce)
+	require.NoError(b, err)
+
+	ciphertext := aead.Seal(nil, nonce, plaintext, nil)
+
+	// Construct payload: ClientPubKey + Nonce + Ciphertext
+	payload := append(clientPubKey, nonce...)
+	payload = append(payload, ciphertext...)
+
+	svc := NewCryptoSvc(serverPrivKey)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(plaintext)))
+
+	// Decrypt modifies input in-place, so we must copy it for each iteration
+	input := make([]byte, len(payload))
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		copy(input, payload)
+		b.StartTimer()
+
+		decrypted, _ := svc.Decrypt(input)
 		if len(decrypted) == 0 {
 			b.Fatal("Decrypt returned empty slice")
 		}


### PR DESCRIPTION
Refactor `tavern/internal/cryptocodec/cryptocodec.go` to maximize bandwidth throughput and reduce GC pressure.

Changes:
1.  **Shared Key Caching**: Introduced an LRU cache for `cipher.AEAD` instances keyed by client public key.
2.  **Zero-Copy Buffer Wrapping**: Replaced `castBytesToBufSlice` with `mem.BufferSlice{mem.SliceBuffer(...)}`.
3.  **Encrypt Optimization**: Pre-allocate a single buffer for public key, nonce, and ciphertext.
4.  **Decrypt Optimization**: Reuse input ciphertext buffer for plaintext output (in-place decryption).

Performance Comparison (from benchmarks):

| Metric | Before (Encrypt 1MB) | After (Encrypt 1MB) | Before (Decrypt 1MB) | After (Decrypt 1MB) |
| :--- | :--- | :--- | :--- | :--- |
| Throughput | ~273 MB/s | **~589 MB/s** | ~506 MB/s | **~1412 MB/s** |
| Allocations | 11 allocs/op | 6 allocs/op | 9 allocs/op | 5 allocs/op |
| Bytes/op | ~2.1 MB | ~1.05 MB | ~1.05 MB | ~2.6 KB |


---
*PR created automatically by Jules for task [9258264799699219581](https://jules.google.com/task/9258264799699219581) started by @KCarretto*