### PR TITLE
Fix IMIX_CONFIG environment variable caching bug

### DIFF
--- a/implants/lib/pb/build.rs
+++ b/implants/lib/pb/build.rs
@@ -284,6 +284,14 @@ fn validate_dsn_config() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Tell Cargo to rerun this build script if these env vars change
+    // This fixes the issue where changing IMIX_CONFIG doesn't trigger a rebuild
+    println!("cargo:rerun-if-env-changed=IMIX_CONFIG");
+    println!("cargo:rerun-if-env-changed=IMIX_CALLBACK_URI");
+    println!("cargo:rerun-if-env-changed=IMIX_CALLBACK_INTERVAL");
+    println!("cargo:rerun-if-env-changed=IMIX_SERVER_PUBKEY");
+    println!("cargo:rerun-if-env-changed=PROTOC");
+
     // Parse YAML config if present (this will emit IMIX_CALLBACK_URI if successful)
     let yaml_config = parse_yaml_config()?;
 


### PR DESCRIPTION
Add cargo:rerun-if-env-changed directives to the pb build script so that
Cargo will rerun the build script when IMIX_CONFIG or other related
environment variables change. Without these directives, Cargo's
incremental build system does not detect environment variable changes
and uses cached build artifacts with stale configuration.

Fixes #1725

https://claude.ai/code/session_01HW5YGLvJBK2nJDziTG6LK6