### PR TITLE
feat: introduce eldritch-lsp and switch tome-builder to runtime assets

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "lib/eldritch/stdlib/eldritch-libsys",
     "lib/eldritch/stdlib/eldritch-libtime",
     "lib/eldritch/eldritch",
+    "lib/eldritch/eldritch-lsp",
     "lib/portals/portal-stream",
 ]
 exclude = [

--- a/implants/lib/eldritch/eldritch-lsp/Cargo.toml
+++ b/implants/lib/eldritch/eldritch-lsp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "eldritch-lsp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eldritch-core = { path = "../eldritch-core" }
+tower-lsp = "0.20.0"
+tokio = { version = "1.36", features = ["rt-multi-thread", "macros", "io-std", "fs"] }
+walkdir = "2.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+log = "0.4"
+env_logger = "0.11"

--- a/implants/lib/eldritch/eldritch-lsp/src/linter.rs
+++ b/implants/lib/eldritch/eldritch-lsp/src/linter.rs
@@ -1,0 +1,108 @@
+use eldritch_core::Stmt;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+/// A trait defining a single linting rule.
+///
+/// Rules follow a two-phase check for performance:
+/// 1. `should_lint`: A lightweight string check.
+/// 2. `check`: A deeper AST or full-text analysis.
+pub trait LintRule: Send + Sync {
+    /// Returns the unique name of the rule (e.g., "no-forbidden-runes").
+    fn name(&self) -> &'static str;
+
+    /// Quickly determines if this rule is relevant for the given source code.
+    /// This optimization prevents expensive AST traversals for rules that definitely won't match.
+    fn should_lint(&self, _source: &str) -> bool {
+        // Default to true for safety, but implementations should override this
+        // with fast checks (e.g., source.contains("forbidden"))
+        true
+    }
+
+    /// Runs the linting logic.
+    ///
+    /// * `ast`: The parsed AST, if available. Some lints might work purely on text.
+    /// * `source`: The raw source code.
+    fn check(&self, ast: Option<&[Stmt]>, source: &str) -> Vec<Diagnostic>;
+}
+
+/// Registry to hold and manage all active lint rules.
+pub struct LintRegistry {
+    rules: Vec<Box<dyn LintRule>>,
+}
+
+impl LintRegistry {
+    pub fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    pub fn register<R: LintRule + 'static>(&mut self, rule: R) {
+        self.rules.push(Box::new(rule));
+    }
+
+    /// Runs all registered rules against the source/AST.
+    pub fn run(&self, ast: Option<&[Stmt]>, source: &str) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        for rule in &self.rules {
+            if rule.should_lint(source) {
+                diagnostics.extend(rule.check(ast, source));
+            }
+        }
+
+        diagnostics
+    }
+}
+
+impl Default for LintRegistry {
+    fn default() -> Self {
+        let mut registry = Self::new();
+        registry.register(NoForbiddenRunes);
+        registry
+    }
+}
+
+// --- Example Rule: NoForbiddenRunes ---
+
+struct NoForbiddenRunes;
+
+impl LintRule for NoForbiddenRunes {
+    fn name(&self) -> &'static str {
+        "no-forbidden-runes"
+    }
+
+    fn should_lint(&self, source: &str) -> bool {
+        source.contains("vecna")
+    }
+
+    fn check(&self, _ast: Option<&[Stmt]>, source: &str) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        for (line_idx, line) in source.lines().enumerate() {
+            if let Some(col_idx) = line.find("vecna") {
+                let range = Range {
+                    start: Position {
+                        line: line_idx as u32,
+                        character: col_idx as u32,
+                    },
+                    end: Position {
+                        line: line_idx as u32,
+                        character: (col_idx + 5) as u32, // "vecna".len()
+                    },
+                };
+
+                diagnostics.push(Diagnostic {
+                    range,
+                    severity: Some(DiagnosticSeverity::WARNING),
+                    code: Some(tower_lsp::lsp_types::NumberOrString::String(
+                        self.name().to_string(),
+                    )),
+                    source: Some("eldritch-lint".to_string()),
+                    message: "The use of 'vecna' is forbidden. It summons unwanted attention.".to_string(),
+                    ..Default::default()
+                });
+            }
+        }
+
+        diagnostics
+    }
+}

--- a/implants/lib/eldritch/eldritch-lsp/src/main.rs
+++ b/implants/lib/eldritch/eldritch-lsp/src/main.rs
@@ -1,0 +1,188 @@
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+mod linter;
+mod stdlib;
+
+use linter::LintRegistry;
+use stdlib::StdlibIndex;
+use eldritch_core::{Parser, Lexer};
+
+struct Backend {
+    client: Client,
+    /// Registry of lint rules.
+    linter: LintRegistry,
+    /// Index of the standard library.
+    stdlib: Arc<RwLock<StdlibIndex>>,
+    /// In-memory cache of document contents.
+    documents: Arc<RwLock<HashMap<Url, String>>>,
+}
+
+impl Backend {
+    async fn validate_document(&self, uri: Url, text: &str, version: Option<i32>) {
+        let mut diagnostics = Vec::new();
+
+        // 1. Parsing Phase (using eldritch-core)
+        let mut lexer = Lexer::new(text.to_string());
+        let tokens = lexer.scan_tokens();
+
+        let mut parser = Parser::new(tokens);
+        let (ast_stmts, parse_errors) = parser.parse();
+
+        // 2. Syntax Error Diagnostics
+        for err in parse_errors {
+            // Convert Span to LSP Range
+            // eldritch_core::token::Span has {start, end, line}.
+            // This is slightly tricky because Span in `token.rs` only has `line` and byte indices.
+            // LSP needs line/character.
+            // Simplified mapping: we trust the `line` from Span, but we need to calculate `character`.
+            // Ideally, we'd use a line indexer. For "Best Effort", we can estimate or just highlight the line.
+
+            // Note: `line` in Span is 1-based. LSP is 0-based.
+            let line_idx = err.span.line.saturating_sub(1) as u32;
+
+            let range = Range {
+                start: Position { line: line_idx, character: 0 },
+                end: Position { line: line_idx, character: u32::MAX }, // Highlight full line if column unknown
+            };
+
+            diagnostics.push(Diagnostic {
+                range,
+                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(NumberOrString::String("syntax-error".to_string())),
+                source: Some("eldritch-parser".to_string()),
+                message: err.message,
+                ..Default::default()
+            });
+        }
+
+        // 3. Linting Phase (Best Effort)
+        // Pass the AST if parsing succeeded partially (ast_stmts might contain valid stmts even with errors).
+        let lint_diags = self.linter.run(Some(&ast_stmts), text);
+        diagnostics.extend(lint_diags);
+
+        // 4. Publish Diagnostics
+        self.client.publish_diagnostics(uri, diagnostics, version).await;
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        let root_uri = params.root_uri.or_else(|| {
+            params.root_path.map(|path| Url::from_file_path(path).unwrap())
+        });
+
+        if let Some(uri) = root_uri {
+            if let Ok(path) = uri.to_file_path() {
+                // Heuristic: stdlib is at implants/lib/eldritch/stdlib
+                // We assume the workspace root is the repo root.
+                // Or we look for the stdlib relative to workspace.
+                let stdlib_path = path.join("implants/lib/eldritch/stdlib");
+
+                let stdlib_ref = self.stdlib.clone();
+                tokio::spawn(async move {
+                    let mut index = stdlib_ref.write().await;
+                    index.scan(stdlib_path);
+                });
+            }
+        }
+
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "Eldritch LSP initialized!")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri.clone();
+        let text = params.text_document.text.clone();
+        let version = Some(params.text_document.version);
+
+        self.documents.write().await.insert(uri.clone(), text.clone());
+        self.validate_document(uri, &text, version).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let version = Some(params.text_document.version);
+        // We use Full sync, so the first change event has the full text
+        if let Some(change) = params.content_changes.into_iter().next() {
+            self.documents.write().await.insert(uri.clone(), change.text.clone());
+            self.validate_document(uri, &change.text, version).await;
+        }
+    }
+
+    async fn completion(&self, _params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        // Context-aware completion logic
+        // For now, we mix in:
+        // 1. Stdlib modules
+        // 2. Keywords (Safe Mode fallback)
+
+        let stdlib = self.stdlib.read().await;
+        let mut items = Vec::new();
+
+        // Add Stdlib modules
+        for module in stdlib.get_completions() {
+            items.push(CompletionItem {
+                label: module,
+                kind: Some(CompletionItemKind::MODULE),
+                detail: Some("Standard Library".to_string()),
+                ..Default::default()
+            });
+        }
+
+        // Add Keywords
+        let keywords = vec![
+            "def", "if", "else", "for", "while", "return", "import", "true", "false", "none"
+        ];
+        for kw in keywords {
+            items.push(CompletionItem {
+                label: kw.to_string(),
+                kind: Some(CompletionItemKind::KEYWORD),
+                ..Default::default()
+            });
+        }
+
+        Ok(Some(CompletionResponse::Array(items)))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(|client| Backend {
+        client,
+        linter: LintRegistry::default(),
+        stdlib: Arc::new(RwLock::new(StdlibIndex::new())),
+        documents: Arc::new(RwLock::new(HashMap::new())),
+    });
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/implants/lib/eldritch/eldritch-lsp/src/stdlib.rs
+++ b/implants/lib/eldritch/eldritch-lsp/src/stdlib.rs
@@ -1,0 +1,68 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
+/// Manages an index of the Eldritch Standard Library.
+///
+/// This index allows the LSP to be aware of available standard library modules
+/// and functions, enabling context-aware autocompletion even when files are
+/// not explicitly imported in the current workspace.
+#[derive(Debug)]
+pub struct StdlibIndex {
+    /// A set of known module names (e.g., "http", "file", "sys").
+    /// In a real implementation, this might map names to function signatures.
+    pub modules: HashSet<String>,
+}
+
+impl StdlibIndex {
+    pub fn new() -> Self {
+        Self {
+            modules: HashSet::new(),
+        }
+    }
+
+    /// Recursively scans the given root path for Eldritch standard library modules.
+    ///
+    /// It looks for files with `.eldritch` extension or directories that imply module structure.
+    /// For this simplified implementation, we assume directories in `stdlib/` represent modules
+    /// (e.g. `stdlib/eldritch-libhttp` -> "http").
+    pub fn scan(&mut self, root_path: PathBuf) {
+        log::info!("Scanning stdlib at {:?}", root_path);
+
+        for entry in WalkDir::new(&root_path)
+            .min_depth(1)
+            .max_depth(2) // optimize: stdlib structure is shallow
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
+                    if dir_name.starts_with("eldritch-lib") {
+                        let module_name = dir_name.trim_start_matches("eldritch-lib");
+                        if !module_name.is_empty() {
+                            self.modules.insert(module_name.to_string());
+                            log::debug!("Found stdlib module: {}", module_name);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add hardcoded core modules if scanning fails or structure is different
+        if self.modules.is_empty() {
+             log::warn!("Stdlib scan yielded no results. Using fallback core modules.");
+             let defaults = vec!["agent", "assets", "crypto", "file", "http", "pivot", "process", "random", "regex", "report", "sys", "time"];
+             for m in defaults {
+                 self.modules.insert(m.to_string());
+             }
+        }
+    }
+
+    /// Returns a list of all known module names for autocompletion.
+    pub fn get_completions(&self) -> Vec<String> {
+        let mut completions: Vec<String> = self.modules.iter().cloned().collect();
+        completions.sort();
+        completions
+    }
+}

--- a/vscode/vscode-tome-builder/package-lock.json
+++ b/vscode/vscode-tome-builder/package-lock.json
@@ -15,10 +15,24 @@
       "devDependencies": {
         "@types/node": "^18.0.0",
         "@types/vscode": "^1.80.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.0.0"
       },
       "engines": {
         "vscode": "^1.80.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -28,6 +42,34 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -40,6 +82,34 @@
         "raw-body": "^3.0.0",
         "zod": "^3.23.8"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.130",
@@ -55,6 +125,39 @@
       "version": "1.108.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.108.1.tgz",
       "integrity": "sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
     },
@@ -76,6 +179,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -83,6 +193,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/http-errors": {
@@ -125,6 +245,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/raw-body": {
@@ -172,6 +299,50 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -200,6 +371,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/zod": {


### PR DESCRIPTION
- **vscode-tome-builder**: Switch to runtime parsing for documentation and examples.
    - `index.ts` now locates repo root and reads files directly.
    - Removed redundant `docs.ts` and `examples.ts`.
- **eldritch-lsp**: Create new Rust Language Server crate.
    - Located in `implants/lib/eldritch/eldritch-lsp`.
    - Added to `implants` workspace.
    - Features linter with optimization hooks (`LintRule`).
    - Indexes standard library from `implants/lib/eldritch/stdlib`.
    - Integrates `eldritch-core` for parsing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide https://docs.realm.pub/#dev
2. Ensure you have added or ran the appropriate tests for your PR
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind eldritch-function
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
