### PR TITLE
[AI] Fix Typos

### DIFF
--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -136,7 +136,7 @@ fn main() -> anyhow::Result<()> {
             });
         }
     }
-    // If we havent specified tomes in INPUT, we need to look through the asset locker for tomes to run
+    // If we haven't specified tomes in INPUT, we need to look through the asset locker for tomes to run
     if parsed_tomes.is_empty() {
         match locker.list() {
             Ok(assets) => {

--- a/tavern/tomes/file_tree/main.eldritch
+++ b/tavern/tomes/file_tree/main.eldritch
@@ -22,14 +22,14 @@ def can_read(f):
     # Are we root?
     root = usernfo["euid"]["uid"] == 0
     
-    # If the user isnt root and the user doesnt own the file, clear the user byte   
+    # If the user isn't root and the user doesn't own the file, clear the user byte
     if not root and f["owner"] not in (usernfo["euid"]["name"], usernfo["uid"]["name"]):
         f_user = 0
     
     # TODO: https://github.com/spellshift/realm/issues/570
     # Will NOT match any group other than primary until #570 is fixed
 
-    # If the user isnt root and the group doesnt own the file, clear the group byte    
+    # If the user isn't root and the group doesn't own the file, clear the group byte
     if not root and f["group"] not in (str(usernfo["egid"]), str(usernfo["gid"])):
         f_group = 0
 


### PR DESCRIPTION
Fixed typos "havent" -> "haven't", "isnt" -> "isn't", "doesnt" -> "doesn't" in comments in `implants/golem/src/main.rs` and `tavern/tomes/file_tree/main.eldritch`.

---
*PR created automatically by Jules for task [3646191931979998926](https://jules.google.com/task/3646191931979998926) started by @KCarretto*