### PR TITLE
Refactor ImixAgent output buffer to use unbounded channel

### DIFF
--- a/implants/imix/src/tests/agent_tests.rs
+++ b/implants/imix/src/tests/agent_tests.rs
@@ -27,12 +27,13 @@ async fn test_start_reverse_shell() {
     let handle = tokio::runtime::Handle::current();
 
     let task_registry = Arc::new(TaskRegistry::new());
-    let agent = Arc::new(ImixAgent::new(
+    let (agent_struct, _rx) = ImixAgent::new(
         Config::default(),
         transport,
         handle,
         task_registry,
-    ));
+    );
+    let agent = Arc::new(agent_struct);
 
     // Execution must happen in a separate thread to allow block_on
     let agent_clone = agent.clone();

--- a/implants/imix/src/tests/callback_interval_test.rs
+++ b/implants/imix/src/tests/callback_interval_test.rs
@@ -14,7 +14,7 @@ async fn test_imix_agent_get_callback_interval_error() {
     let transport = MockTransport::default();
     let handle = tokio::runtime::Handle::current();
     let registry = Arc::new(TaskRegistry::new());
-    let agent = ImixAgent::new(config, transport, handle, registry);
+    let (agent, _rx) = ImixAgent::new(config, transport, handle, registry);
 
     let result = agent.get_callback_interval_u64();
     assert!(result.is_err());
@@ -40,7 +40,7 @@ async fn test_imix_agent_get_callback_interval_success() {
     let transport = MockTransport::default();
     let handle = tokio::runtime::Handle::current();
     let registry = Arc::new(TaskRegistry::new());
-    let agent = ImixAgent::new(config, transport, handle, registry);
+    let (agent, _rx) = ImixAgent::new(config, transport, handle, registry);
 
     let result = agent.get_callback_interval_u64();
     assert!(result.is_ok());
@@ -74,7 +74,7 @@ async fn test_set_callback_uri_new_transport() {
     let transport = MockTransport::default();
     let handle = tokio::runtime::Handle::current();
     let registry = Arc::new(TaskRegistry::new());
-    let agent = ImixAgent::new(config, transport, handle, registry);
+    let (agent, _rx) = ImixAgent::new(config, transport, handle, registry);
 
     // Run in thread for block_on
     let agent_clone = agent.clone();
@@ -152,7 +152,7 @@ async fn test_set_callback_uri_existing_transport() {
     let transport = MockTransport::default();
     let handle = tokio::runtime::Handle::current();
     let registry = Arc::new(TaskRegistry::new());
-    let agent = ImixAgent::new(config, transport, handle, registry);
+    let (agent, _rx) = ImixAgent::new(config, transport, handle, registry);
 
     // Run in thread for block_on
     let agent_clone = agent.clone();


### PR DESCRIPTION
Resolved deadlock issues in `imix` agent by replacing the mutex-protected output buffer with a `tokio::sync::mpsc::unbounded_channel`. 

Key changes:
- `ImixAgent` struct now holds `output_tx` (UnboundedSender) instead of `output_buffer`.
- `ImixAgent::new` returns `(Self, UnboundedReceiver)`.
- `run_agent` manages the receiver and passes it to `flush_outputs`.
- `flush_outputs` drains the channel using a loop with `tokio::time::timeout` of 100ms, satisfying the requirement to gather available messages within a time window.
- Updated `report_task_output` to send to the channel.
- Updated all relevant tests in `agent_tests.rs`, `agent_trait_tests.rs`, and `callback_interval_test.rs`.

This change ensures that `report_task_output` (producer) never blocks on `flush_outputs` (consumer), and `flush_outputs` does not hold a `!Send` MutexGuard across await points, maintaining `Send` compliance for the multi-threaded runtime.

---
*PR created automatically by Jules for task [12466601352763447780](https://jules.google.com/task/12466601352763447780) started by @KCarretto*