### PR TITLE
[bug] SOCKS5 trim space and newline from tavern auth file

### DIFF
--- a/bin/socks5/auth.go
+++ b/bin/socks5/auth.go
@@ -45,7 +45,7 @@ func getAuthToken(ctx context.Context, tavernURL, cachePath string) (auth.Token,
 	}
 
 	log.Printf("Loaded authentication credentials from %q", cachePath)
-	return auth.Token(tokenData), nil
+	return auth.Token(strings.TrimSpace(string(tokenData))), nil
 }
 
 func authGRPCContext(ctx context.Context, upstream string, authCachePath string) context.Context {


### PR DESCRIPTION
Make the auth file more useable