### PR TITLE
Remove unnecessary useEffect in Assets modals by conditional rendering

### DIFF
--- a/tavern/internal/www/src/pages/assets/Assets.tsx
+++ b/tavern/internal/www/src/pages/assets/Assets.tsx
@@ -56,7 +56,7 @@ export const Assets = () => {
                 />
             </div>
 
-            {selectedAsset && (
+            {createLinkModalOpen && selectedAsset && (
                 <CreateLinkModal
                     isOpen={createLinkModalOpen}
                     setOpen={setCreateLinkModalOpen}
@@ -66,11 +66,13 @@ export const Assets = () => {
                 />
             )}
 
-            <UploadAssetModal
-                isOpen={uploadAssetModalOpen}
-                setOpen={setUploadAssetModalOpen}
-                onUploadSuccess={handleRefresh}
-            />
+            {uploadAssetModalOpen && (
+                <UploadAssetModal
+                    isOpen={uploadAssetModalOpen}
+                    setOpen={setUploadAssetModalOpen}
+                    onUploadSuccess={handleRefresh}
+                />
+            )}
         </>
     );
 };

--- a/tavern/internal/www/src/pages/assets/components/CreateLinkModal.tsx
+++ b/tavern/internal/www/src/pages/assets/components/CreateLinkModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect } from "react";
+import { FC, useState } from "react";
 import Modal from "../../../components/tavern-base-ui/Modal";
 import Button from "../../../components/tavern-base-ui/button/Button";
 import AlertError from "../../../components/tavern-base-ui/AlertError";
@@ -39,7 +39,7 @@ const CreateLinkModal: FC<CreateLinkModalProps> = ({ isOpen, setOpen, assetId, a
             hasDownloadLimit: false,
             expiryMode: 0, // 0: 10m, 1: 1h, 2: Custom
             expiresAt: format(add(new Date(), { days: 1 }), "yyyy-MM-dd'T'HH:mm"),
-            path: "",
+            path: generateRandomString(12),
         },
         validationSchema: yup.object({
             path: yup.string().required("Path is required"),
@@ -92,22 +92,6 @@ const CreateLinkModal: FC<CreateLinkModalProps> = ({ isOpen, setOpen, assetId, a
             }
         },
     });
-
-    useEffect(() => {
-        if (isOpen) {
-            setCreatedLink(null);
-            setError(null);
-            formik.setValues({
-                downloadLimit: 1,
-                hasDownloadLimit: false,
-                expiryMode: 0,
-                expiresAt: format(add(new Date(), { days: 1 }), "yyyy-MM-dd'T'HH:mm"),
-                path: generateRandomString(12),
-            });
-            formik.setTouched({});
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen]);
 
     const handleCopy = () => {
         if (createdLink) {
@@ -240,7 +224,7 @@ const CreateLinkModal: FC<CreateLinkModalProps> = ({ isOpen, setOpen, assetId, a
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-gray-700">
+                            <label htmlFor="path" className="block text-sm font-medium text-gray-700">
                                 Path
                             </label>
                             <div className="flex rounded-md shadow-sm mt-1">
@@ -249,6 +233,7 @@ const CreateLinkModal: FC<CreateLinkModalProps> = ({ isOpen, setOpen, assetId, a
                                 </span>
                                 <input
                                     type="text"
+                                    id="path"
                                     name="path"
                                     required
                                     value={formik.values.path}

--- a/tavern/internal/www/src/pages/assets/components/UploadAssetModal.tsx
+++ b/tavern/internal/www/src/pages/assets/components/UploadAssetModal.tsx
@@ -1,5 +1,5 @@
 import { Upload, Folder, File as FileIcon, X, CheckCircle, Loader2, Pencil, AlertTriangle } from "lucide-react";
-import { FC, useState, useRef, useEffect } from "react";
+import { FC, useState, useRef } from "react";
 import { useFormik } from "formik";
 import Modal from "../../../components/tavern-base-ui/Modal";
 import Button from "../../../components/tavern-base-ui/button/Button";
@@ -222,13 +222,6 @@ const UploadAssetModal: FC<UploadAssetModalProps> = ({ isOpen, setOpen, onUpload
             }
         },
     });
-
-    useEffect(() => {
-        if (isOpen) {
-            formik.resetForm();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen]);
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files.length > 0) {

--- a/tavern/internal/www/src/pages/assets/components/__tests__/CreateLinkModal.test.tsx
+++ b/tavern/internal/www/src/pages/assets/components/__tests__/CreateLinkModal.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateLinkModal from '../CreateLinkModal';
+import { render } from '../../../../test-utils';
+
+// Mock useCreateLink
+const mockCreateLink = vi.fn();
+
+vi.mock('../../useAssets', () => ({
+    useCreateLink: () => ({
+        createLink: mockCreateLink,
+        loading: false,
+        error: null,
+        data: null
+    }),
+}));
+
+// Mock Modal to simplify testing
+vi.mock('../../../components/tavern-base-ui/Modal', () => ({
+    default: ({ children, isOpen, setOpen }: any) => {
+        if (!isOpen) return null;
+        return (
+            <div role="dialog">
+                <button onClick={() => setOpen(false)} aria-label="Close panel">Close</button>
+                {children}
+            </div>
+        );
+    }
+}));
+
+describe('CreateLinkModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders and initializes form values correctly', async () => {
+        const setOpen = vi.fn();
+        render(
+            <CreateLinkModal
+                isOpen={true}
+                setOpen={setOpen}
+                assetId="123"
+                assetName="Test Asset"
+            />
+        );
+
+        expect(screen.getByText('Create link for Test Asset')).toBeInTheDocument();
+
+        // Check path initialization (random string)
+        const pathInput = screen.getByLabelText(/path/i) as HTMLInputElement;
+        expect(pathInput.value).not.toBe('');
+        expect(pathInput.value).toHaveLength(12);
+        expect(pathInput.value).toMatch(/^[A-Za-z0-9]+$/);
+    });
+
+    it('submits form with correct values', async () => {
+        const user = userEvent.setup();
+        const setOpen = vi.fn();
+        const onSuccess = vi.fn();
+
+        // Mock successful response
+        mockCreateLink.mockResolvedValue({
+            data: {
+                createLink: {
+                    path: 'new-link-path'
+                }
+            }
+        });
+
+        render(
+            <CreateLinkModal
+                isOpen={true}
+                setOpen={setOpen}
+                assetId="123"
+                assetName="Test Asset"
+                onSuccess={onSuccess}
+            />
+        );
+
+        // Fill form
+        // Path is pre-filled, let's keep it or change it
+        const pathInput = screen.getByLabelText(/path/i);
+        await user.clear(pathInput);
+        await user.type(pathInput, 'custom-path');
+
+        // Submit
+        const submitButton = screen.getByText('Create Link');
+        await user.click(submitButton);
+
+        await waitFor(() => {
+            expect(mockCreateLink).toHaveBeenCalledWith({
+                variables: {
+                    input: expect.objectContaining({
+                        assetID: '123',
+                        path: 'custom-path',
+                        downloadLimit: null, // Default
+                        // expiryMode 0 -> 10 mins from now roughly
+                    })
+                }
+            });
+        });
+
+        // Success UI should show
+        expect(await screen.findByText('Link Created!')).toBeInTheDocument();
+        expect(screen.getByText(/new-link-path/)).toBeInTheDocument();
+    });
+
+    it('validates required fields', async () => {
+        const user = userEvent.setup();
+        const setOpen = vi.fn();
+
+        render(
+            <CreateLinkModal
+                isOpen={true}
+                setOpen={setOpen}
+                assetId="123"
+                assetName="Test Asset"
+            />
+        );
+
+        const pathInput = screen.getByLabelText(/path/i);
+        await user.clear(pathInput);
+
+        const submitButton = screen.getByText('Create Link');
+        await user.click(submitButton);
+
+        // Path is required
+        expect(await screen.findByText('Path is required')).toBeInTheDocument();
+        expect(mockCreateLink).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Refactored Assets.tsx to conditionally render CreateLinkModal and UploadAssetModal, ensuring they unmount when closed. This allowed removing unnecessary useEffect hooks that were resetting state in those components. Added unit tests for CreateLinkModal.

---
*PR created automatically by Jules for task [9941601491016949383](https://jules.google.com/task/9941601491016949383) started by @KCarretto*