### PR TITLE
Refactor Assets page to use userId instead of creatorId for filtering

### DIFF
--- a/tavern/internal/www/src/components/UserFilterBar.tsx
+++ b/tavern/internal/www/src/components/UserFilterBar.tsx
@@ -13,7 +13,7 @@ const UserFilterBar = () => {
         label: edge.node.name,
     })) || [];
 
-    const selectedOption = options.find((option) => option.value === filters.creatorId);
+    const selectedOption = options.find((option) => option.value === filters.userId);
 
     return (
         <div className="flex flex-col gap-1">
@@ -22,11 +22,11 @@ const UserFilterBar = () => {
                 isDisabled={filters.isLocked || loading}
                 isLoading={loading}
                 isClearable
-                placeholder="Filter by Creator"
+                placeholder="Filter by User"
                 options={options}
                 value={selectedOption}
                 onChange={(option) => {
-                    updateFilters({ creatorId: option ? option.value : "" });
+                    updateFilters({ userId: option ? option.value : "" });
                 }}
             />
         </div>

--- a/tavern/internal/www/src/context/FilterContext/FilterContext.tsx
+++ b/tavern/internal/www/src/context/FilterContext/FilterContext.tsx
@@ -9,10 +9,10 @@ export enum FilterFieldType {
     TOME_FIELDS = 'tomeFields',
     TOME_MULTI_SEARCH = "tomeMultiSearch",
     ASSET_NAME = "assetName",
-    CREATOR = "creator"
+    USER = "user"
 }
 
-const STORAGE_KEY = 'realm-filters-v1.1'
+const STORAGE_KEY = 'realm-filters-v1.2'
 
 export type Filters = {
     isLocked: boolean,
@@ -22,7 +22,7 @@ export type Filters = {
     tomeFields: Array<FilterBarOption>,
     tomeMultiSearch: string,
     assetName: string,
-    creatorId: string,
+    userId: string,
 }
 
 const defaultFilters: Filters = {
@@ -33,7 +33,7 @@ const defaultFilters: Filters = {
     tomeFields: [],
     tomeMultiSearch: "",
     assetName: "",
-    creatorId: ""
+    userId: ""
 }
 
 function isValidFilterBarOption(item: any): item is FilterBarOption {
@@ -60,7 +60,7 @@ function validateStoredFilters(data: any): Filters {
         taskOutput: (v) => typeof v === 'string',
         tomeMultiSearch: (v) => typeof v === 'string',
         assetName: (v) => typeof v === 'string',
-        creatorId: (v) => typeof v === 'string',
+        userId: (v) => typeof v === 'string',
         beaconFields: (v) => Array.isArray(v) && v.every(isValidFilterBarOption),
         tomeFields: (v) => Array.isArray(v) && v.every(isValidFilterBarOption),
     }
@@ -103,8 +103,8 @@ export function calculateFilterCount(filters: Filters, field: FilterFieldType): 
             return filters.tomeMultiSearch !== "" ? 1 : 0;
         case FilterFieldType.ASSET_NAME:
             return filters.assetName !== "" ? 1 : 0;
-        case FilterFieldType.CREATOR:
-            return filters.creatorId !== "" ? 1 : 0;
+        case FilterFieldType.USER:
+            return filters.userId !== "" ? 1 : 0;
         case FilterFieldType.BEACON_FIELDS:
             return filters.beaconFields.length;
         case FilterFieldType.TOME_FIELDS:

--- a/tavern/internal/www/src/context/FilterContext/FilterControls.tsx
+++ b/tavern/internal/www/src/context/FilterContext/FilterControls.tsx
@@ -24,7 +24,7 @@ function getFilterFields(pathname: string): FilterFieldType[] | null {
         return [FilterFieldType.BEACON_FIELDS, FilterFieldType.TOME_FIELDS, FilterFieldType.TOME_MULTI_SEARCH, FilterFieldType.TASK_OUTPUT];
     }
     if (pathname === '/assets') {
-        return [FilterFieldType.ASSET_NAME, FilterFieldType.CREATOR];
+        return [FilterFieldType.ASSET_NAME, FilterFieldType.USER];
     }
 
     return null;
@@ -120,7 +120,7 @@ export default function FilterControls() {
                 </div>
             );
         }
-        else if (field === FilterFieldType.CREATOR) {
+        else if (field === FilterFieldType.USER) {
             return (
                 <div key={field}>
                     <UserFilterBar />

--- a/tavern/internal/www/src/context/FilterContext/__tests__/FilterContext.test.tsx
+++ b/tavern/internal/www/src/context/FilterContext/__tests__/FilterContext.test.tsx
@@ -5,7 +5,7 @@ import { FilterBarOption } from '../../../utils/interfacesUI';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 
-const STORAGE_KEY = 'realm-filters-v1.1';
+const STORAGE_KEY = 'realm-filters-v1.2';
 
 const createWrapper = (initialEntries: string[] = ['/']) => {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -37,7 +37,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       });
     });
 
@@ -50,7 +50,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: 'search-term',
         assetName: '',
-        creatorId: '',
+        userId: '',
       };
 
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(storedFilters));
@@ -71,7 +71,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: 'search-term',
         assetName: '',
-        creatorId: '',
+        userId: '',
       };
 
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(storedFilters));
@@ -88,7 +88,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       });
     });
 
@@ -109,7 +109,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       });
       expect(result.current.filterCount).toBe(0);
     });
@@ -131,7 +131,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       });
     });
 
@@ -184,7 +184,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       };
 
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(validFilters));
@@ -298,7 +298,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       });
     });
 
@@ -327,7 +327,7 @@ describe('FilterContext', () => {
           tomeFields: [],
           tomeMultiSearch: '',
           assetName: '',
-          creatorId: '',
+          userId: '',
         });
       });
     });
@@ -347,7 +347,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: 'external-search',
         assetName: '',
-        creatorId: '',
+        userId: '',
       };
 
       act(() => {
@@ -379,7 +379,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: 'external-search',
         assetName: '',
-        creatorId: '',
+        userId: '',
       };
 
       act(() => {
@@ -399,7 +399,7 @@ describe('FilterContext', () => {
         tomeFields: [],
         tomeMultiSearch: '',
         assetName: '',
-        creatorId: '',
+        userId: '',
       });
     });
 
@@ -431,7 +431,7 @@ describe('FilterContext', () => {
       tomeFields: [],
       tomeMultiSearch: '',
       assetName: '',
-      creatorId: '',
+      userId: '',
     };
 
     it('should return 1 for non-empty questName', () => {
@@ -493,7 +493,7 @@ describe('FilterContext', () => {
       tomeFields: [],
       tomeMultiSearch: '',
       assetName: '',
-      creatorId: '',
+      userId: '',
     };
 
     it('should return 0 when all filters are empty', () => {
@@ -530,7 +530,7 @@ describe('FilterContext', () => {
           { kind: 'tome', id: '1', name: 'T1' },
         ],
         assetName: '',
-        creatorId: '',
+        userId: '',
       };
 
       const allFields = Object.values(FilterFieldType);

--- a/tavern/internal/www/src/pages/assets/Assets.tsx
+++ b/tavern/internal/www/src/pages/assets/Assets.tsx
@@ -12,8 +12,8 @@ export const Assets = () => {
     const rowLimit = 10;
     const { filters } = useFilters();
     const where: any = filters.assetName ? { nameContains: filters.assetName } : {};
-    if (filters.creatorId) {
-        where.hasCreatorWith = [{ id: filters.creatorId }];
+    if (filters.userId) {
+        where.hasCreatorWith = [{ id: filters.userId }];
     }
 
     const { assets, loading, error, totalCount, pageInfo, refetch, updateAssets, page, setPage } = useAssets(rowLimit, where);


### PR DESCRIPTION
Renamed creatorId to userId in FilterContext and related components to support generic user filtering. Updated tests.

---
*PR created automatically by Jules for task [8179373684837659041](https://jules.google.com/task/8179373684837659041) started by @KCarretto*