### PR TITLE
Display file max size errors on selection in UploadAssetModal

### DIFF
--- a/tavern/internal/www/src/pages/assets/components/UploadAssetModal/UploadAssetModal.test.tsx
+++ b/tavern/internal/www/src/pages/assets/components/UploadAssetModal/UploadAssetModal.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "../../../../test-utils";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UploadAssetModal from "./UploadAssetModal";
+import { MAX_FILE_SIZE } from "./upload";
+import { vi, describe, it, expect } from "vitest";
+
+describe("UploadAssetModal", () => {
+    it("displays error when file size exceeds limit", async () => {
+        const user = userEvent.setup();
+        const setOpen = vi.fn();
+        const onUploadSuccess = vi.fn();
+
+        render(
+            <UploadAssetModal isOpen={true} setOpen={setOpen} onUploadSuccess={onUploadSuccess} />
+        );
+
+        // Create a dummy file
+        const file = new File(["dummy content"], "large-file.txt", { type: "text/plain" });
+        // Mock the size property to exceed the limit
+        Object.defineProperty(file, 'size', { value: MAX_FILE_SIZE + 1 });
+
+        const input = screen.getByTestId("file-upload-input");
+        await user.upload(input, file);
+
+        const errorMessage = await screen.findByText("File size exceeds 100MB limit");
+        expect(errorMessage).toBeInTheDocument();
+    });
+
+    it("does not display error for valid file size", async () => {
+        const user = userEvent.setup();
+        const setOpen = vi.fn();
+        const onUploadSuccess = vi.fn();
+
+        render(
+            <UploadAssetModal isOpen={true} setOpen={setOpen} onUploadSuccess={onUploadSuccess} />
+        );
+
+        // Create a valid file
+        const file = new File(["valid content"], "valid-file.txt", { type: "text/plain" });
+        // Mock the size property to be within limit
+        Object.defineProperty(file, 'size', { value: MAX_FILE_SIZE - 1 });
+
+        const input = screen.getByTestId("file-upload-input");
+        await user.upload(input, file);
+
+        expect(screen.queryByText("File size exceeds 100MB limit")).not.toBeInTheDocument();
+        expect(screen.getByText("valid-file.txt")).toBeInTheDocument();
+    });
+});

--- a/tavern/internal/www/src/pages/assets/components/UploadAssetModal/UploadAssetModal.tsx
+++ b/tavern/internal/www/src/pages/assets/components/UploadAssetModal/UploadAssetModal.tsx
@@ -4,7 +4,7 @@ import { useFormik } from "formik";
 import Modal from "../../../../components/tavern-base-ui/Modal";
 import Button from "../../../../components/tavern-base-ui/button/Button";
 import FileCard, { FileItem } from "./FileCard";
-import { uploadFiles } from "./upload";
+import { uploadFiles, MAX_FILE_SIZE } from "./upload";
 
 type UploadAssetModalProps = {
     isOpen: boolean;
@@ -36,8 +36,9 @@ const UploadAssetModal: FC<UploadAssetModalProps> = ({ isOpen, setOpen, onUpload
                 id: Math.random().toString(36).substring(7) + Date.now(),
                 file,
                 name: file.webkitRelativePath || file.name,
-                status: "pending",
-                progress: 0
+                status: file.size > MAX_FILE_SIZE ? "error" : "pending",
+                progress: 0,
+                error: file.size > MAX_FILE_SIZE ? "File size exceeds 100MB limit" : undefined
             }));
             formik.setFieldValue("files", [...formik.values.files, ...newFiles]);
 
@@ -94,6 +95,7 @@ const UploadAssetModal: FC<UploadAssetModalProps> = ({ isOpen, setOpen, onUpload
                                 onChange={handleFileChange}
                                 className="hidden"
                                 disabled={formik.isSubmitting}
+                                data-testid="file-upload-input"
                             />
                             <input
                                 type="file"

--- a/tavern/internal/www/src/pages/assets/components/UploadAssetModal/upload.ts
+++ b/tavern/internal/www/src/pages/assets/components/UploadAssetModal/upload.ts
@@ -1,6 +1,6 @@
 import { FileItem } from "./FileCard";
 
-const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
 
 interface uploadFileParams {
     files: FileItem[];

--- a/tavern/internal/www/start.log
+++ b/tavern/internal/www/start.log
@@ -1,0 +1,56 @@
+
+> www@0.1.0 start
+> react-scripts start
+
+(node:3032) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+(node:3032) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
+Starting the development server...
+
+Compiled with warnings.
+
+[eslint]
+src/components/UserFilterBar.tsx
+  Line 1:10:  'gql' is defined but never used  @typescript-eslint/no-unused-vars
+
+src/components/form-steps/FormSteps.tsx
+  Line 25:7:  The element ol has an implicit role of list. Defining this explicitly is redundant and should be avoided  jsx-a11y/no-redundant-roles
+
+src/components/tavern-base-ui/Tooltip.tsx
+  Line 1:10:  'useToast' is defined but never used  @typescript-eslint/no-unused-vars
+
+src/pages/assets/components/CreateLinkModal/CreateLinkForm.tsx
+  Line 1:10:  'useFormik' is defined but never used  @typescript-eslint/no-unused-vars
+
+src/pages/shell/Shell.tsx
+  Line 73:8:  React Hook useEffect has a missing dependency: 'toast'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+
+src/utils/utils.ts
+  Line 43:50:    Unexpected use of comma operator  no-sequences
+  Line 130:118:  Unexpected use of comma operator  no-sequences
+
+Search for the keywords to learn more about each warning.
+To ignore, add // eslint-disable-next-line to the line before.
+
+WARNING in [eslint]
+src/components/UserFilterBar.tsx
+  Line 1:10:  'gql' is defined but never used  @typescript-eslint/no-unused-vars
+
+src/components/form-steps/FormSteps.tsx
+  Line 25:7:  The element ol has an implicit role of list. Defining this explicitly is redundant and should be avoided  jsx-a11y/no-redundant-roles
+
+src/components/tavern-base-ui/Tooltip.tsx
+  Line 1:10:  'useToast' is defined but never used  @typescript-eslint/no-unused-vars
+
+src/pages/assets/components/CreateLinkModal/CreateLinkForm.tsx
+  Line 1:10:  'useFormik' is defined but never used  @typescript-eslint/no-unused-vars
+
+src/pages/shell/Shell.tsx
+  Line 73:8:  React Hook useEffect has a missing dependency: 'toast'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+
+src/utils/utils.ts
+  Line 43:50:    Unexpected use of comma operator  no-sequences
+  Line 130:118:  Unexpected use of comma operator  no-sequences
+
+webpack compiled with 1 warning
+No issues found.


### PR DESCRIPTION
Updated UploadAssetModal to validate file size immediately upon selection. Files exceeding 100MB are now marked with an error status and display "File size exceeds 100MB limit" before the user attempts to upload. Added a unit test to verify this behavior.

---
*PR created automatically by Jules for task [14592160947290800029](https://jules.google.com/task/14592160947290800029) started by @KCarretto*