### PR TITLE
[AI] Expand Test Coverage - eldritch-core/parser

### DIFF
--- a/implants/lib/eldritch/eldritch-core/src/parser/expr.rs
+++ b/implants/lib/eldritch/eldritch-core/src/parser/expr.rs
@@ -497,6 +497,8 @@ impl Parser {
     fn finish_call(&mut self, callee: Expr) -> Result<Expr, EldritchError> {
         let start = callee.span;
         let mut args = Vec::new();
+        let mut seen_keyword_style_arg = false;
+
         if !self.check(&TokenKind::RParen) {
             loop {
                 let is_keyword = if let TokenKind::Identifier(_) = self.peek().kind {
@@ -506,11 +508,15 @@ impl Parser {
                 };
 
                 if self.match_token(&[TokenKind::Star]) {
+                    if seen_keyword_style_arg {
+                        return self.error("Iterable argument unpacking follows keyword argument.");
+                    }
                     let expr = self.expression()?;
                     args.push(Argument::StarArgs(expr));
                 } else if self.match_token(&[TokenKind::StarStar]) {
                     let expr = self.expression()?;
                     args.push(Argument::KwArgs(expr));
+                    seen_keyword_style_arg = true;
                 } else if is_keyword {
                     // FIX: Clone to avoid borrow issues, ensure advance is done
                     let name_token = self.advance();
@@ -522,7 +528,11 @@ impl Parser {
                     self.advance(); // Consume '='
                     let val = self.expression()?;
                     args.push(Argument::Keyword(name, val));
+                    seen_keyword_style_arg = true;
                 } else {
+                    if seen_keyword_style_arg {
+                        return self.error("Positional argument follows keyword argument.");
+                    }
                     args.push(Argument::Positional(self.expression()?));
                 }
 

--- a/implants/lib/eldritch/eldritch-core/tests/parser_call_validation.rs
+++ b/implants/lib/eldritch/eldritch-core/tests/parser_call_validation.rs
@@ -1,0 +1,66 @@
+use eldritch_core::{Lexer, Parser};
+
+fn parse_stmts(code: &str) -> Result<Vec<eldritch_core::Stmt>, String> {
+    let mut lexer = Lexer::new(code.to_string());
+    let tokens = lexer.scan_tokens();
+    let mut parser = Parser::new(tokens);
+    let (stmts, errors) = parser.parse();
+    if errors.is_empty() {
+        Ok(stmts)
+    } else {
+        Err(errors[0].message.clone())
+    }
+}
+
+#[test]
+fn test_positional_after_keyword() {
+    let code = "f(a=1, 2)";
+    let result = parse_stmts(code);
+    assert!(
+        result.is_err(),
+        "Should fail with positional argument after keyword argument"
+    );
+    assert!(
+        result
+            .unwrap_err()
+            .contains("Positional argument follows keyword argument")
+    );
+}
+
+#[test]
+fn test_positional_after_kwargs() {
+    // f(**kwargs, 1) is invalid
+    let code = "f(**k, 1)";
+    let result = parse_stmts(code);
+    assert!(
+        result.is_err(),
+        "Should fail with positional argument after **kwargs"
+    );
+}
+
+#[test]
+fn test_star_args_after_keyword() {
+    // f(a=1, *args) is invalid
+    let code = "f(a=1, *args)";
+    let result = parse_stmts(code);
+    assert!(
+        result.is_err(),
+        "Should fail with *args after keyword argument"
+    );
+    assert!(
+        result
+            .unwrap_err()
+            .contains("Iterable argument unpacking follows keyword argument")
+    );
+}
+
+#[test]
+fn test_valid_calls() {
+    // f(1, *args, a=2, **kwargs) is valid
+    let code = "f(1, *args, a=2, **kwargs)";
+    assert!(parse_stmts(code).is_ok());
+
+    // f(1, *args, a=2) is valid
+    let code = "f(1, *args, a=2)";
+    assert!(parse_stmts(code).is_ok());
+}


### PR DESCRIPTION
Implemented strict argument ordering validation in `eldritch-core` parser for function calls.
Added `seen_keyword_style_arg` flag in `finish_call` to track if keyword arguments or `**kwargs` have been encountered.
If a positional argument or `*args` is encountered after a keyword argument, a syntax error is returned.
Added `implants/lib/eldritch/eldritch-core/tests/parser_call_validation.rs` to test valid and invalid call scenarios.
Verified stability by running the new tests 20 times.
Ran regression tests for `eldritch-core` to ensure no side effects.

---
*PR created automatically by Jules for task [5210219499630704701](https://jules.google.com/task/5210219499630704701) started by @KCarretto*