### PR TITLE
[AI] Fix Typos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,5 @@ bundle exec jekyll serve --livereload
 
 ## Docsy Jekyll Template
 
-* [Source on Github](https://github.com/vsoch/docsy-jekyll)
-* [View on Github Pages](https://vsoch.github.io/docsy-jekyll/)
+* [Source on GitHub](https://github.com/vsoch/docsy-jekyll)
+* [View on GitHub Pages](https://vsoch.github.io/docsy-jekyll/)

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -58,7 +58,7 @@ var (
 	EnvOAuthClientSecret = EnvString{"OAUTH_CLIENT_SECRET", ""}
 	EnvOAuthDomain       = EnvString{"OAUTH_DOMAIN", ""}
 
-	// EnvMySQLAddr defines the MySQL address to connect to, if unset SQLLite is used.
+	// EnvMySQLAddr defines the MySQL address to connect to, if unset SQLite is used.
 	// EnvMySQLNet defines the network used to connect to MySQL (e.g. unix).
 	// EnvMySQLUser defines the MySQL user to authenticate as.
 	// EnvMySQLPasswd defines the password for the MySQL user to authenticate with.

--- a/tavern/config_test.go
+++ b/tavern/config_test.go
@@ -27,7 +27,7 @@ func TestConfigureMySQLFromEnv(t *testing.T) {
 		require.NoError(t, os.Unsetenv(EnvDBMaxConnLifetime.Key))
 	}
 
-	t.Run("SQLLite", func(t *testing.T) {
+	t.Run("SQLite", func(t *testing.T) {
 		defer cleanup()
 
 		cfg := &Config{}
@@ -80,7 +80,7 @@ func TestConfigureMySQLFromEnv(t *testing.T) {
 		assert.Equal(t, "root@tcp(127.0.0.1)/tavern?parseTime=true", cfg.mysqlDSN)
 	})
 
-	t.Run("SQLLite", func(t *testing.T) {
+	t.Run("SQLite", func(t *testing.T) {
 		defer cleanup()
 		require.NoError(t, os.Setenv(EnvDBMaxIdleConns.Key, "1337"))
 		require.NoError(t, os.Setenv(EnvDBMaxOpenConns.Key, "420"))

--- a/tavern/internal/cdn/download_link.go
+++ b/tavern/internal/cdn/download_link.go
@@ -2,8 +2,8 @@ package cdn
 
 import (
 	"bytes"
-	"net/http"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
@@ -55,15 +55,15 @@ func NewLinkDownloadHandler(graph *ent.Client, prefix string) http.Handler {
 		if l.DownloadLimit != nil {
 			downloadLimit = *l.DownloadLimit
 		}
-		if  downloadLimit > 0 && l.Downloads >= downloadLimit {
+		if downloadLimit > 0 && l.Downloads >= downloadLimit {
 			slog.Info("Failed attempt to download link, maximum downloads reached", "path", linkPath, "downloads", l.Downloads, "download_limit", l.DownloadLimit)
 			return ErrFileNotFound
 		}
 
 		// Increment Link Downloads
 		if _, err := graph.Link.UpdateOne(l).
-		SetDownloads(l.Downloads + 1).
-		Save(ctx); err != nil {
+			SetDownloads(l.Downloads + 1).
+			Save(ctx); err != nil {
 			slog.Error("failed to increment downloads for link", "path", linkPath, "downloads", l.Downloads, "err", err)
 
 			// Only error if a download limit is enforced

--- a/tavern/internal/ent/schema/link_test.go
+++ b/tavern/internal/ent/schema/link_test.go
@@ -30,9 +30,9 @@ func TestCreateLinkWithExplicitExpiresAt(t *testing.T) {
 	futureTime := time.Now().Add(24 * time.Hour)
 	downloadLimit := 5
 	input := ent.CreateLinkInput{
-		AssetID:            asset.ID,
-		DownloadLimit:      &downloadLimit,
-		ExpiresAt:          &futureTime,
+		AssetID:       asset.ID,
+		DownloadLimit: &downloadLimit,
+		ExpiresAt:     &futureTime,
 	}
 
 	link, err := graph.Link.Create().SetInput(input).Save(ctx)

--- a/tavern/internal/redirectors/tls.go
+++ b/tavern/internal/redirectors/tls.go
@@ -51,9 +51,9 @@ func tryACME(ctx context.Context, host string) (tlsCfg *tls.Config, err error) {
 		slog.Debug("redirectors: using short lived certificates")
 	}
 	acme := certmagic.ACMEIssuer{
-		Agreed: true,
-		Email:  "",
-		CA:     certmagic.LetsEncryptProductionCA,
+		Agreed:  true,
+		Email:   "",
+		CA:      certmagic.LetsEncryptProductionCA,
 		Profile: profile,
 	}
 
@@ -85,9 +85,8 @@ func selfSignedTLSConfig(host string) (*tls.Config, error) {
 	}
 
 	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-		},
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,

--- a/tavern/internal/www/src/pages/tomes/components/StepAddDeploymentKey.tsx
+++ b/tavern/internal/www/src/pages/tomes/components/StepAddDeploymentKey.tsx
@@ -26,8 +26,8 @@ const StepAddDeploymentKey: FC<StepAddDeploymentKeyProps> = ({ setCurrStep, newR
                     To import tomes, you need to give Realm access to your git repository. Copy the public key below into your repositories deployment keys, often found in admin settings.
                 </p>
                 <ul className="text-sm list-disc px-4 py-2">
-                    <li>Setup for <a className="external-link" rel="noreferrer" target="_blank" href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#set-up-deploy-keys">Github</a></li>
-                    <li>Setup for  <a className="external-link" rel="noreferrer" target="_blank" href="https://docs.gitlab.com/ee/user/project/deploy_keys/#create-a-project-deploy-key">Gitlab</a></li>
+                    <li>Setup for <a className="external-link" rel="noreferrer" target="_blank" href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#set-up-deploy-keys">GitHub</a></li>
+                    <li>Setup for  <a className="external-link" rel="noreferrer" target="_blank" href="https://docs.gitlab.com/ee/user/project/deploy_keys/#create-a-project-deploy-key">GitLab</a></li>
                     <li>Setup for  <a className="external-link" rel="noreferrer" target="_blank" href="https://bitbucket.org/blog/deployment-keys">Bitbucket</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
This PR addresses several typos and capitalization inconsistencies found in the repository:

1.  **Backend Config**: Corrected `SQLLite` to `SQLite` in `tavern/config.go` comments and `tavern/config_test.go` test names.
2.  **Frontend UI**: Updated "Github" to "GitHub" and "Gitlab" to "GitLab" in `tavern/internal/www/src/pages/tomes/components/StepAddDeploymentKey.tsx` to match brand guidelines.
3.  **Documentation**: Updated "Github" to "GitHub" in `docs/README.md`.

Testing:
- Ran `go fmt ./tavern/...`
- Ran `go test ./tavern/...` (All tests passed)
- Frontend verification was skipped as changes are minor text corrections and local environment lacks frontend dependencies.

---
*PR created automatically by Jules for task [248227581347966274](https://jules.google.com/task/248227581347966274) started by @KCarretto*