### PR TITLE
[AI] Fix Typos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ cargo fmt
 3. **Rust Formatting**: Always run `cargo fmt` - CI will fail without it.
 4. **Linear History**: Use squash merge for PRs.
 5. **React Components**: Avoid large ternary operations, instead break out the two pieces into components and use a simple ternary operation e.g. `condition ? <ComponentA /> : <ComponentB />`
-6. **React Utilities**: Separate styling from logic and abstract reuseable functions into utils files.
+6. **React Utilities**: Separate styling from logic and abstract reusable functions into utils files.
 7. **React Styling**: Attempt to reference existing pages and components for style guidelines, be sure to re-use components and match styling to maintain consistency.
 8. **Prefer Line-of-Sight Coding**: Avoid large indentation by returning early and keeping an unnested control flow, for example:
 

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -119,7 +119,7 @@ var (
 	EnvSecretsManagerPath = EnvString{"SECRETS_FILE_PATH", ""}
 )
 
-// Config holds information that controls the behaviour of Tavern
+// Config holds information that controls the behavior of Tavern
 type Config struct {
 	srv *http.Server
 

--- a/tavern/internal/cdn/download_link.go
+++ b/tavern/internal/cdn/download_link.go
@@ -2,8 +2,8 @@ package cdn
 
 import (
 	"bytes"
-	"net/http"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
@@ -55,15 +55,15 @@ func NewLinkDownloadHandler(graph *ent.Client, prefix string) http.Handler {
 		if l.DownloadLimit != nil {
 			downloadLimit = *l.DownloadLimit
 		}
-		if  downloadLimit > 0 && l.Downloads >= downloadLimit {
+		if downloadLimit > 0 && l.Downloads >= downloadLimit {
 			slog.Info("Failed attempt to download link, maximum downloads reached", "path", linkPath, "downloads", l.Downloads, "download_limit", l.DownloadLimit)
 			return ErrFileNotFound
 		}
 
 		// Increment Link Downloads
 		if _, err := graph.Link.UpdateOne(l).
-		SetDownloads(l.Downloads + 1).
-		Save(ctx); err != nil {
+			SetDownloads(l.Downloads + 1).
+			Save(ctx); err != nil {
 			slog.Error("failed to increment downloads for link", "path", linkPath, "downloads", l.Downloads, "err", err)
 
 			// Only error if a download limit is enforced

--- a/tavern/internal/ent/schema/link_test.go
+++ b/tavern/internal/ent/schema/link_test.go
@@ -30,9 +30,9 @@ func TestCreateLinkWithExplicitExpiresAt(t *testing.T) {
 	futureTime := time.Now().Add(24 * time.Hour)
 	downloadLimit := 5
 	input := ent.CreateLinkInput{
-		AssetID:            asset.ID,
-		DownloadLimit:      &downloadLimit,
-		ExpiresAt:          &futureTime,
+		AssetID:       asset.ID,
+		DownloadLimit: &downloadLimit,
+		ExpiresAt:     &futureTime,
 	}
 
 	link, err := graph.Link.Create().SetInput(input).Save(ctx)

--- a/tavern/internal/errors/http_test.go
+++ b/tavern/internal/errors/http_test.go
@@ -10,7 +10,7 @@ import (
 	"realm.pub/tavern/internal/errors"
 )
 
-// TestWrapHandler asserts that wrapped handlers exhibit expected behaviour.
+// TestWrapHandler asserts that wrapped handlers exhibit expected behavior.
 func TestWrapHandler(t *testing.T) {
 	t.Run("BasicError", newWrapHandlerTest(
 		errors.NewHTTP("some error", 101),

--- a/tavern/internal/redirectors/tls.go
+++ b/tavern/internal/redirectors/tls.go
@@ -51,9 +51,9 @@ func tryACME(ctx context.Context, host string) (tlsCfg *tls.Config, err error) {
 		slog.Debug("redirectors: using short lived certificates")
 	}
 	acme := certmagic.ACMEIssuer{
-		Agreed: true,
-		Email:  "",
-		CA:     certmagic.LetsEncryptProductionCA,
+		Agreed:  true,
+		Email:   "",
+		CA:      certmagic.LetsEncryptProductionCA,
 		Profile: profile,
 	}
 
@@ -85,9 +85,8 @@ func selfSignedTLSConfig(host string) (*tls.Config, error) {
 	}
 
 	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-		},
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,


### PR DESCRIPTION
This PR fixes spelling errors in `AGENTS.md` and Go source files.
Specifically:
- `AGENTS.md`: "reuseable" -> "reusable"
- `tavern/config.go`: "behaviour" -> "behavior" (in comment)
- `tavern/internal/errors/http_test.go`: "behaviour" -> "behavior" (in comment)

Ran `go fmt ./...` and `go test ./...` to ensure correctness.

---
*PR created automatically by Jules for task [14906559020994278372](https://jules.google.com/task/14906559020994278372) started by @KCarretto*