### PR TITLE
[AI] Fix Typos

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -64,7 +64,7 @@ markdown: kramdown
 tag_color: primary # danger, success, warning, primary, info, secondary
 
 accentColor: red # purple, green, etc.
-themeColor: red # purple, green, blue, orange, purple, grey
+themeColor: red # purple, green, blue, orange, purple, gray
 fixedNav: 'true' # true or false
 
 permalink: /:year/:title/

--- a/docs/_includes/scrolltop.html
+++ b/docs/_includes/scrolltop.html
@@ -17,7 +17,7 @@
 }
 
 #scrolltop:hover {
-  background-color: #555; /* Add a dark-grey background on hover */
+  background-color: #555; /* Add a dark-gray background on hover */
 }
 </style>
 <button onclick="topFunction()" id="scrolltop" title="Go to top">🔝</button>

--- a/tavern/cli/auth/auth.go
+++ b/tavern/cli/auth/auth.go
@@ -121,7 +121,7 @@ func Authenticate(ctx context.Context, browser Browser, tavernURL string) (Token
 	// Wait for Token, Error, or Cancellation
 	select {
 	case <-ctx.Done():
-		return Token(""), fmt.Errorf("authentication cancelled: %w", ctx.Err())
+		return Token(""), fmt.Errorf("authentication canceled: %w", ctx.Err())
 	case err := <-errCh:
 		return Token(""), fmt.Errorf("failed to obtain credentials: %w", err)
 	case token := <-tokenCh:

--- a/tavern/config.go
+++ b/tavern/config.go
@@ -119,7 +119,7 @@ var (
 	EnvSecretsManagerPath = EnvString{"SECRETS_FILE_PATH", ""}
 )
 
-// Config holds information that controls the behaviour of Tavern
+// Config holds information that controls the behavior of Tavern
 type Config struct {
 	srv *http.Server
 

--- a/tavern/internal/auth/oauth_test.go
+++ b/tavern/internal/auth/oauth_test.go
@@ -22,7 +22,7 @@ import (
 	"realm.pub/tavern/internal/ent/user"
 )
 
-// TestNewOAuthLoginHandler ensures the OAuth Login Handler exhibits expected behaviour
+// TestNewOAuthLoginHandler ensures the OAuth Login Handler exhibits expected behavior
 func TestNewOAuthLoginHandler(t *testing.T) {
 	// Generate keys for signing JWTs
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
@@ -78,7 +78,7 @@ func TestNewOAuthLoginHandler(t *testing.T) {
 	assert.Less(t, claims.ExpiresAt.Time.Unix(), time.Now().Add(11*time.Minute).Unix())
 }
 
-// TestNewOAuthAuthorizationHandler ensures the OAuth Authorization Handler exhibits expected behaviour
+// TestNewOAuthAuthorizationHandler ensures the OAuth Authorization Handler exhibits expected behavior
 func TestNewOAuthAuthorizationHandler(t *testing.T) {
 	var (
 		expectedClientID     = "12345"

--- a/tavern/internal/cdn/download_link.go
+++ b/tavern/internal/cdn/download_link.go
@@ -2,8 +2,8 @@ package cdn
 
 import (
 	"bytes"
-	"net/http"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
@@ -55,15 +55,15 @@ func NewLinkDownloadHandler(graph *ent.Client, prefix string) http.Handler {
 		if l.DownloadLimit != nil {
 			downloadLimit = *l.DownloadLimit
 		}
-		if  downloadLimit > 0 && l.Downloads >= downloadLimit {
+		if downloadLimit > 0 && l.Downloads >= downloadLimit {
 			slog.Info("Failed attempt to download link, maximum downloads reached", "path", linkPath, "downloads", l.Downloads, "download_limit", l.DownloadLimit)
 			return ErrFileNotFound
 		}
 
 		// Increment Link Downloads
 		if _, err := graph.Link.UpdateOne(l).
-		SetDownloads(l.Downloads + 1).
-		Save(ctx); err != nil {
+			SetDownloads(l.Downloads + 1).
+			Save(ctx); err != nil {
 			slog.Error("failed to increment downloads for link", "path", linkPath, "downloads", l.Downloads, "err", err)
 
 			// Only error if a download limit is enforced

--- a/tavern/internal/ent/schema/link_test.go
+++ b/tavern/internal/ent/schema/link_test.go
@@ -30,9 +30,9 @@ func TestCreateLinkWithExplicitExpiresAt(t *testing.T) {
 	futureTime := time.Now().Add(24 * time.Hour)
 	downloadLimit := 5
 	input := ent.CreateLinkInput{
-		AssetID:            asset.ID,
-		DownloadLimit:      &downloadLimit,
-		ExpiresAt:          &futureTime,
+		AssetID:       asset.ID,
+		DownloadLimit: &downloadLimit,
+		ExpiresAt:     &futureTime,
 	}
 
 	link, err := graph.Link.Create().SetInput(input).Save(ctx)

--- a/tavern/internal/errors/http_test.go
+++ b/tavern/internal/errors/http_test.go
@@ -10,7 +10,7 @@ import (
 	"realm.pub/tavern/internal/errors"
 )
 
-// TestWrapHandler asserts that wrapped handlers exhibit expected behaviour.
+// TestWrapHandler asserts that wrapped handlers exhibit expected behavior.
 func TestWrapHandler(t *testing.T) {
 	t.Run("BasicError", newWrapHandlerTest(
 		errors.NewHTTP("some error", 101),

--- a/tavern/internal/portals/mux/benchmark_test.go
+++ b/tavern/internal/portals/mux/benchmark_test.go
@@ -77,7 +77,7 @@ func BenchmarkMuxThroughput(b *testing.B) {
 		case <-hostCh:
 			// Success
 		case <-ctx.Done():
-			b.Fatal("Context cancelled")
+			b.Fatal("Context canceled")
 		}
 
 		// 2. Host sends to Client (TopicOut)
@@ -90,7 +90,7 @@ func BenchmarkMuxThroughput(b *testing.B) {
 		case <-clientCh:
 			// Success
 		case <-ctx.Done():
-			b.Fatal("Context cancelled")
+			b.Fatal("Context canceled")
 		}
 	}
 }

--- a/tavern/internal/redirectors/http1/grpc_stream_test.go
+++ b/tavern/internal/redirectors/http1/grpc_stream_test.go
@@ -54,7 +54,7 @@ func TestCreateStreamWithContext(t *testing.T) {
 	// Verify context can be used for timeout checks
 	select {
 	case <-ctx.Done():
-		t.Error("Context should not be cancelled yet")
+		t.Error("Context should not be canceled yet")
 	default:
 		// Expected
 	}

--- a/tavern/internal/redirectors/tls.go
+++ b/tavern/internal/redirectors/tls.go
@@ -51,9 +51,9 @@ func tryACME(ctx context.Context, host string) (tlsCfg *tls.Config, err error) {
 		slog.Debug("redirectors: using short lived certificates")
 	}
 	acme := certmagic.ACMEIssuer{
-		Agreed: true,
-		Email:  "",
-		CA:     certmagic.LetsEncryptProductionCA,
+		Agreed:  true,
+		Email:   "",
+		CA:      certmagic.LetsEncryptProductionCA,
 		Profile: profile,
 	}
 
@@ -85,9 +85,8 @@ func selfSignedTLSConfig(host string) (*tls.Config, error) {
 	}
 
 	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-		},
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,


### PR DESCRIPTION
This PR fixes several typos found in the codebase and documentation to adhere to American English spelling conventions.

Modifications:
- `docs/_config.yml`: `grey` -> `gray`
- `docs/_includes/scrolltop.html`: `grey` -> `gray`
- `tavern/config.go`: `behaviour` -> `behavior`
- `tavern/cli/auth/auth.go`: `authentication cancelled` -> `authentication canceled`
- `tavern/internal/redirectors/http1/grpc_stream_test.go`: `cancelled` -> `canceled`
- `tavern/internal/auth/oauth_test.go`: `behaviour` -> `behavior`
- `tavern/internal/portals/mux/benchmark_test.go`: `cancelled` -> `canceled`
- `tavern/internal/errors/http_test.go`: `behaviour` -> `behavior`

Ran `go fmt ./...` and `go test ./...` in `tavern`.
Deleted temporary scripts `scan_typos.py` and `scan_typos_v2.py`.

---
*PR created automatically by Jules for task [5398432195582195875](https://jules.google.com/task/5398432195582195875) started by @KCarretto*