### PR TITLE
[AI] Fix Typos

### DIFF
--- a/tavern/internal/graphql/generated/root_.generated.go
+++ b/tavern/internal/graphql/generated/root_.generated.go
@@ -7283,7 +7283,7 @@ scalar Uint64
   """The platform the agent is operating on."""
   hostPlatform: HostPlatform!
 
-  """The IP address of the hosts primary interface (if available)."""
+  """The IP address of the host's primary interface (if available)."""
   hostPrimaryIP: String
 
   """Unique identifier of the beacon, each running instance will be different."""

--- a/tavern/internal/graphql/models/gqlgen_models.go
+++ b/tavern/internal/graphql/models/gqlgen_models.go
@@ -19,7 +19,7 @@ type ClaimTasksInput struct {
 	Hostname string `json:"hostname"`
 	// The platform the agent is operating on.
 	HostPlatform c2pb.Host_Platform `json:"hostPlatform"`
-	// The IP address of the hosts primary interface (if available).
+	// The IP address of the host's primary interface (if available).
 	HostPrimaryIP *string `json:"hostPrimaryIP,omitempty"`
 	// Unique identifier of the beacon, each running instance will be different.
 	BeaconIdentifier string `json:"beaconIdentifier"`

--- a/tavern/internal/graphql/schema.graphql
+++ b/tavern/internal/graphql/schema.graphql
@@ -4261,7 +4261,7 @@ input ClaimTasksInput {
   """The platform the agent is operating on."""
   hostPlatform: HostPlatform!
 
-  """The IP address of the hosts primary interface (if available)."""
+  """The IP address of the host's primary interface (if available)."""
   hostPrimaryIP: String
 
   """Unique identifier of the beacon, each running instance will be different."""

--- a/tavern/internal/graphql/schema/inputs.graphql
+++ b/tavern/internal/graphql/schema/inputs.graphql
@@ -8,7 +8,7 @@ input ClaimTasksInput {
   """The platform the agent is operating on."""
   hostPlatform: HostPlatform!
 
-  """The IP address of the hosts primary interface (if available)."""
+  """The IP address of the host's primary interface (if available)."""
   hostPrimaryIP: String
 
   """Unique identifier of the beacon, each running instance will be different."""

--- a/tavern/internal/portals/mux/benchmark_test.go
+++ b/tavern/internal/portals/mux/benchmark_test.go
@@ -77,7 +77,7 @@ func BenchmarkMuxThroughput(b *testing.B) {
 		case <-hostCh:
 			// Success
 		case <-ctx.Done():
-			b.Fatal("Context cancelled")
+			b.Fatal("Context canceled")
 		}
 
 		// 2. Host sends to Client (TopicOut)
@@ -90,7 +90,7 @@ func BenchmarkMuxThroughput(b *testing.B) {
 		case <-clientCh:
 			// Success
 		case <-ctx.Done():
-			b.Fatal("Context cancelled")
+			b.Fatal("Context canceled")
 		}
 	}
 }

--- a/tavern/internal/www/schema.graphql
+++ b/tavern/internal/www/schema.graphql
@@ -4261,7 +4261,7 @@ input ClaimTasksInput {
   """The platform the agent is operating on."""
   hostPlatform: HostPlatform!
 
-  """The IP address of the hosts primary interface (if available)."""
+  """The IP address of the host's primary interface (if available)."""
   hostPrimaryIP: String
 
   """Unique identifier of the beacon, each running instance will be different."""


### PR DESCRIPTION
This PR fixes a few typos found in the codebase.
- Corrected "cancelled" to "canceled" in benchmark test to match American English convention used in the repo.
- Corrected "hosts" to "host's" in GraphQL schema documentation for `hostPrimaryIP`.
- Regenerated code using `go generate ./...`.

---
*PR created automatically by Jules for task [4612856619537946519](https://jules.google.com/task/4612856619537946519) started by @KCarretto*