### PR TITLE
Reuse StreamPrinter implementation in imix/shell

### DIFF
--- a/implants/imix/src/lib.rs
+++ b/implants/imix/src/lib.rs
@@ -3,6 +3,7 @@ extern crate alloc;
 pub mod agent;
 pub mod assets;
 pub mod portal;
+pub mod printer;
 pub mod run;
 pub mod shell;
 pub mod task;

--- a/implants/imix/src/main.rs
+++ b/implants/imix/src/main.rs
@@ -23,6 +23,7 @@ mod agent;
 mod assets;
 mod install;
 mod portal;
+mod printer;
 mod run;
 mod shell;
 mod task;

--- a/implants/imix/src/printer.rs
+++ b/implants/imix/src/printer.rs
@@ -1,0 +1,31 @@
+use eldritch::{Printer, Span};
+use tokio::sync::mpsc::UnboundedSender;
+
+#[derive(Debug, Clone)]
+pub enum OutputKind {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug)]
+pub struct StreamPrinter {
+    tx: UnboundedSender<(OutputKind, String)>,
+}
+
+impl StreamPrinter {
+    pub fn new(tx: UnboundedSender<(OutputKind, String)>) -> Self {
+        Self { tx }
+    }
+}
+
+impl Printer for StreamPrinter {
+    fn print_out(&self, _span: &Span, s: &str) {
+        // We format with newline to match BufferPrinter behavior which separates lines
+        let _ = self.tx.send((OutputKind::Stdout, format!("{}\n", s)));
+    }
+
+    fn print_err(&self, _span: &Span, s: &str) {
+        // We format with newline to match BufferPrinter behavior
+        let _ = self.tx.send((OutputKind::Stderr, format!("{}\n", s)));
+    }
+}


### PR DESCRIPTION
Refactor imix/shell to reuse StreamPrinter implementation

Moved `StreamPrinter` from `imix/src/task.rs` to `imix/src/printer.rs` and updated it to distinguish between `Stdout` and `Stderr` using an `OutputKind` enum.
Updated `imix/src/shell/repl.rs` to reuse `StreamPrinter` instead of the custom `ShellPrinter`.
Refactored `imix/src/task.rs` to use the shared `StreamPrinter` and properly report stderr to `TaskError` field.
Updated `imix/src/lib.rs` and `imix/src/main.rs` to include the new `printer` module.
This change unifies output handling across the agent and improves maintainability.

---
*PR created automatically by Jules for task [10663336750935921147](https://jules.google.com/task/10663336750935921147) started by @KCarretto*