### PR TITLE
fix(www): Wrap Field.Label in Field.Root for Chakra UI v3 compatibility

### DIFF
--- a/tavern/internal/www/src/components/tavern-base-ui/FormTextField.tsx
+++ b/tavern/internal/www/src/components/tavern-base-ui/FormTextField.tsx
@@ -7,7 +7,7 @@ type Props = {
 const FormTextField = (props: Props) => {
     const {htmlFor, label, ...rest} = props;
     return (
-        <div>
+        <Field.Root>
             <Field.Label htmlFor={htmlFor}>
                 <Heading size="sm" >{label}</Heading>
             </Field.Label>
@@ -17,7 +17,7 @@ const FormTextField = (props: Props) => {
                 {...rest}
                 size='sm'
             />
-        </div>
+        </Field.Root>
     );
 }
 export default FormTextField;

--- a/tavern/internal/www/src/pages/create-quest/components/BeaconStep.tsx
+++ b/tavern/internal/www/src/pages/create-quest/components/BeaconStep.tsx
@@ -101,7 +101,7 @@ const BeaconStep = (props: Props) => {
                             <BeaconFilterBar filtersSelected={typeFilters} setFiltersSelected={setTypeFilters} hideStatusFilter={true} />
                         </div>
                         <div className="flex-1 flex flex-col gap-2">
-                            <div className="flex flex-row-reverse md:flex-row gap-1 justify-end">
+                            <Field.Root orientation="horizontal" className="flex flex-row-reverse md:flex-row gap-1 justify-end">
                                 <Field.Label htmlFor='isSelected' className="mt-1">
                                     <Heading size="sm" >View only selected beacons</Heading>
                                 </Field.Label>
@@ -111,7 +111,7 @@ const BeaconStep = (props: Props) => {
                                         <Switch.Thumb />
                                     </Switch.Control>
                                 </Switch.Root>
-                            </div>
+                            </Field.Root>
                             <Tooltip
                                 content="Show only one beacon per host, prioritizing admin privileges and more reliable transports"
                                 bg="white"
@@ -122,7 +122,7 @@ const BeaconStep = (props: Props) => {
                                     placement: "bottom"
                                 }}
                             >
-                                <div className="flex flex-row-reverse md:flex-row gap-1 justify-end">
+                                <Field.Root orientation="horizontal" className="flex flex-row-reverse md:flex-row gap-1 justify-end">
                                     <Field.Label htmlFor='isOnePerHost' className="mt-1">
                                         <Heading size="sm" >View one beacon per host</Heading>
                                     </Field.Label>
@@ -132,7 +132,7 @@ const BeaconStep = (props: Props) => {
                                         <Switch.Thumb />
                                     </Switch.Control>
                                 </Switch.Root>
-                                </div>
+                                </Field.Root>
                             </Tooltip>
                         </div>
                     </div>

--- a/tavern/internal/www/src/pages/host-details/components/CredentialTab.tsx
+++ b/tavern/internal/www/src/pages/host-details/components/CredentialTab.tsx
@@ -19,7 +19,7 @@ const CredentialTab = () => {
                 <div className="col-span-1 md:col-span-2">
                     <FreeTextSearch placeholder={searchPlaceholder} setSearch={setSearch} />
                 </div>
-                <div className="flex flex-row-reverse md:flex-row gap-1 justify-center">
+                <Field.Root orientation="horizontal" className="flex flex-row-reverse md:flex-row gap-1 justify-center">
                     <Field.Label htmlFor='groupByPrincipal' className="mt-1">
                         <Heading size="sm" >Group by Principal/Kind</Heading>
                     </Field.Label>
@@ -29,7 +29,7 @@ const CredentialTab = () => {
                             <Switch.Thumb />
                         </Switch.Control>
                     </Switch.Root>
-                </div>
+                </Field.Root>
             </div>
             <div className="flex flex-col justify-center items-center gap-6">
                 {(loading) ? (


### PR DESCRIPTION
This commit fixes a runtime error in BeaconStep.tsx where Field.Label was used without a Field.Root provider, which is required in Chakra UI v3. The fix wraps Field.Label and related input components (Switch.Root or Input) in Field.Root. This pattern was also applied to FormTextField.tsx and CredentialTab.tsx to prevent similar errors.

---
*PR created automatically by Jules for task [13705429278332448321](https://jules.google.com/task/13705429278332448321) started by @KCarretto*