### PR TITLE
Fix imix agent stream printing output separation

### DIFF
--- a/implants/imix/src/printer.rs
+++ b/implants/imix/src/printer.rs
@@ -1,31 +1,26 @@
 use eldritch::{Printer, Span};
 use tokio::sync::mpsc::UnboundedSender;
 
-#[derive(Debug, Clone)]
-pub enum OutputKind {
-    Stdout,
-    Stderr,
-}
-
 #[derive(Debug)]
 pub struct StreamPrinter {
-    tx: UnboundedSender<(OutputKind, String)>,
+    tx: UnboundedSender<String>,
+    error_tx: UnboundedSender<String>,
 }
 
 impl StreamPrinter {
-    pub fn new(tx: UnboundedSender<(OutputKind, String)>) -> Self {
-        Self { tx }
+    pub fn new(tx: UnboundedSender<String>, error_tx: UnboundedSender<String>) -> Self {
+        Self { tx, error_tx }
     }
 }
 
 impl Printer for StreamPrinter {
     fn print_out(&self, _span: &Span, s: &str) {
         // We format with newline to match BufferPrinter behavior which separates lines
-        let _ = self.tx.send((OutputKind::Stdout, format!("{}\n", s)));
+        let _ = self.tx.send(format!("{}\n", s));
     }
 
     fn print_err(&self, _span: &Span, s: &str) {
         // We format with newline to match BufferPrinter behavior
-        let _ = self.tx.send((OutputKind::Stderr, format!("{}\n", s)));
+        let _ = self.error_tx.send(format!("{}\n", s));
     }
 }


### PR DESCRIPTION
Separated stdout and stderr in `StreamPrinter` into two distinct channels to fix broken stream printing functionality. Updated `imix` agent task execution and REPL to consume both streams concurrently, ensuring output and errors are correctly reported and aggregated.

---
*PR created automatically by Jules for task [2068944275940564324](https://jules.google.com/task/2068944275940564324) started by @KCarretto*