### PR TITLE
feat: Support creating portals from ShellTask context

### DIFF
--- a/tavern/internal/ent/client.go
+++ b/tavern/internal/ent/client.go
@@ -2071,6 +2071,22 @@ func (c *PortalClient) QueryTask(po *Portal) *TaskQuery {
 	return query
 }
 
+// QueryShellTask queries the shell_task edge of a Portal.
+func (c *PortalClient) QueryShellTask(po *Portal) *ShellTaskQuery {
+	query := (&ShellTaskClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := po.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(portal.Table, portal.FieldID, id),
+			sqlgraph.To(shelltask.Table, shelltask.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, portal.ShellTaskTable, portal.ShellTaskColumn),
+		)
+		fromV = sqlgraph.Neighbors(po.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryBeacon queries the beacon edge of a Portal.
 func (c *PortalClient) QueryBeacon(po *Portal) *BeaconQuery {
 	query := (&BeaconClient{config: c.config}).Query()

--- a/tavern/internal/ent/gql_collection.go
+++ b/tavern/internal/ent/gql_collection.go
@@ -2316,6 +2316,17 @@ func (po *PortalQuery) collectField(ctx context.Context, oneNode bool, opCtx *gr
 			}
 			po.withTask = query
 
+		case "shellTask":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&ShellTaskClient{config: po.config}).Query()
+			)
+			if err := query.collectField(ctx, oneNode, opCtx, field, path, mayAddCondition(satisfies, shelltaskImplementors)...); err != nil {
+				return err
+			}
+			po.withShellTask = query
+
 		case "beacon":
 			var (
 				alias = field.Alias
@@ -2381,10 +2392,10 @@ func (po *PortalQuery) collectField(ctx context.Context, oneNode bool, opCtx *gr
 						}
 						for i := range nodes {
 							n := m[nodes[i].ID]
-							if nodes[i].Edges.totalCount[3] == nil {
-								nodes[i].Edges.totalCount[3] = make(map[string]int)
+							if nodes[i].Edges.totalCount[4] == nil {
+								nodes[i].Edges.totalCount[4] = make(map[string]int)
 							}
-							nodes[i].Edges.totalCount[3][alias] = n
+							nodes[i].Edges.totalCount[4][alias] = n
 						}
 						return nil
 					})
@@ -2392,10 +2403,10 @@ func (po *PortalQuery) collectField(ctx context.Context, oneNode bool, opCtx *gr
 					po.loadTotal = append(po.loadTotal, func(_ context.Context, nodes []*Portal) error {
 						for i := range nodes {
 							n := len(nodes[i].Edges.ActiveUsers)
-							if nodes[i].Edges.totalCount[3] == nil {
-								nodes[i].Edges.totalCount[3] = make(map[string]int)
+							if nodes[i].Edges.totalCount[4] == nil {
+								nodes[i].Edges.totalCount[4] = make(map[string]int)
 							}
-							nodes[i].Edges.totalCount[3][alias] = n
+							nodes[i].Edges.totalCount[4][alias] = n
 						}
 						return nil
 					})

--- a/tavern/internal/ent/gql_edge.go
+++ b/tavern/internal/ent/gql_edge.go
@@ -343,7 +343,15 @@ func (po *Portal) Task(ctx context.Context) (*Task, error) {
 	if IsNotLoaded(err) {
 		result, err = po.QueryTask().Only(ctx)
 	}
-	return result, err
+	return result, MaskNotFound(err)
+}
+
+func (po *Portal) ShellTask(ctx context.Context) (*ShellTask, error) {
+	result, err := po.Edges.ShellTaskOrErr()
+	if IsNotLoaded(err) {
+		result, err = po.QueryShellTask().Only(ctx)
+	}
+	return result, MaskNotFound(err)
 }
 
 func (po *Portal) Beacon(ctx context.Context) (*Beacon, error) {
@@ -370,7 +378,7 @@ func (po *Portal) ActiveUsers(
 		WithUserFilter(where.Filter),
 	}
 	alias := graphql.GetFieldContext(ctx).Field.Alias
-	totalCount, hasTotalCount := po.Edges.totalCount[3][alias]
+	totalCount, hasTotalCount := po.Edges.totalCount[4][alias]
 	if nodes, err := po.NamedActiveUsers(alias); err == nil || hasTotalCount {
 		pager, err := newUserPager(opts, last != nil)
 		if err != nil {

--- a/tavern/internal/ent/gql_where_input.go
+++ b/tavern/internal/ent/gql_where_input.go
@@ -5006,6 +5006,10 @@ type PortalWhereInput struct {
 	HasTask     *bool             `json:"hasTask,omitempty"`
 	HasTaskWith []*TaskWhereInput `json:"hasTaskWith,omitempty"`
 
+	// "shell_task" edge predicates.
+	HasShellTask     *bool                  `json:"hasShellTask,omitempty"`
+	HasShellTaskWith []*ShellTaskWhereInput `json:"hasShellTaskWith,omitempty"`
+
 	// "beacon" edge predicates.
 	HasBeacon     *bool               `json:"hasBeacon,omitempty"`
 	HasBeaconWith []*BeaconWhereInput `json:"hasBeaconWith,omitempty"`
@@ -5210,6 +5214,24 @@ func (i *PortalWhereInput) P() (predicate.Portal, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, portal.HasTaskWith(with...))
+	}
+	if i.HasShellTask != nil {
+		p := portal.HasShellTask()
+		if !*i.HasShellTask {
+			p = portal.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasShellTaskWith) > 0 {
+		with := make([]predicate.ShellTask, 0, len(i.HasShellTaskWith))
+		for _, w := range i.HasShellTaskWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasShellTaskWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, portal.HasShellTaskWith(with...))
 	}
 	if i.HasBeacon != nil {
 		p := portal.HasBeacon()

--- a/tavern/internal/ent/migrate/schema.go
+++ b/tavern/internal/ent/migrate/schema.go
@@ -325,7 +325,8 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "last_modified_at", Type: field.TypeTime},
 		{Name: "closed_at", Type: field.TypeTime, Nullable: true},
-		{Name: "portal_task", Type: field.TypeInt},
+		{Name: "portal_task", Type: field.TypeInt, Nullable: true},
+		{Name: "portal_shell_task", Type: field.TypeInt, Nullable: true},
 		{Name: "portal_beacon", Type: field.TypeInt},
 		{Name: "portal_owner", Type: field.TypeInt},
 		{Name: "shell_portals", Type: field.TypeInt, Nullable: true},
@@ -340,23 +341,29 @@ var (
 				Symbol:     "portals_tasks_task",
 				Columns:    []*schema.Column{PortalsColumns[4]},
 				RefColumns: []*schema.Column{TasksColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "portals_shell_tasks_shell_task",
+				Columns:    []*schema.Column{PortalsColumns[5]},
+				RefColumns: []*schema.Column{ShellTasksColumns[0]},
+				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "portals_beacons_beacon",
-				Columns:    []*schema.Column{PortalsColumns[5]},
+				Columns:    []*schema.Column{PortalsColumns[6]},
 				RefColumns: []*schema.Column{BeaconsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "portals_users_owner",
-				Columns:    []*schema.Column{PortalsColumns[6]},
+				Columns:    []*schema.Column{PortalsColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "portals_shells_portals",
-				Columns:    []*schema.Column{PortalsColumns[7]},
+				Columns:    []*schema.Column{PortalsColumns[8]},
 				RefColumns: []*schema.Column{ShellsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -758,9 +765,10 @@ func init() {
 		Collation: "utf8mb4_general_ci",
 	}
 	PortalsTable.ForeignKeys[0].RefTable = TasksTable
-	PortalsTable.ForeignKeys[1].RefTable = BeaconsTable
-	PortalsTable.ForeignKeys[2].RefTable = UsersTable
-	PortalsTable.ForeignKeys[3].RefTable = ShellsTable
+	PortalsTable.ForeignKeys[1].RefTable = ShellTasksTable
+	PortalsTable.ForeignKeys[2].RefTable = BeaconsTable
+	PortalsTable.ForeignKeys[3].RefTable = UsersTable
+	PortalsTable.ForeignKeys[4].RefTable = ShellsTable
 	PortalsTable.Annotation = &entsql.Annotation{
 		Collation: "utf8mb4_general_ci",
 	}

--- a/tavern/internal/ent/mutation.go
+++ b/tavern/internal/ent/mutation.go
@@ -9467,6 +9467,8 @@ type PortalMutation struct {
 	clearedFields       map[string]struct{}
 	task                *int
 	clearedtask         bool
+	shell_task          *int
+	clearedshell_task   bool
 	beacon              *int
 	clearedbeacon       bool
 	owner               *int
@@ -9735,6 +9737,45 @@ func (m *PortalMutation) TaskIDs() (ids []int) {
 func (m *PortalMutation) ResetTask() {
 	m.task = nil
 	m.clearedtask = false
+}
+
+// SetShellTaskID sets the "shell_task" edge to the ShellTask entity by id.
+func (m *PortalMutation) SetShellTaskID(id int) {
+	m.shell_task = &id
+}
+
+// ClearShellTask clears the "shell_task" edge to the ShellTask entity.
+func (m *PortalMutation) ClearShellTask() {
+	m.clearedshell_task = true
+}
+
+// ShellTaskCleared reports if the "shell_task" edge to the ShellTask entity was cleared.
+func (m *PortalMutation) ShellTaskCleared() bool {
+	return m.clearedshell_task
+}
+
+// ShellTaskID returns the "shell_task" edge ID in the mutation.
+func (m *PortalMutation) ShellTaskID() (id int, exists bool) {
+	if m.shell_task != nil {
+		return *m.shell_task, true
+	}
+	return
+}
+
+// ShellTaskIDs returns the "shell_task" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// ShellTaskID instead. It exists only for internal usage by the builders.
+func (m *PortalMutation) ShellTaskIDs() (ids []int) {
+	if id := m.shell_task; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetShellTask resets all changes to the "shell_task" edge.
+func (m *PortalMutation) ResetShellTask() {
+	m.shell_task = nil
+	m.clearedshell_task = false
 }
 
 // SetBeaconID sets the "beacon" edge to the Beacon entity by id.
@@ -10045,9 +10086,12 @@ func (m *PortalMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *PortalMutation) AddedEdges() []string {
-	edges := make([]string, 0, 4)
+	edges := make([]string, 0, 5)
 	if m.task != nil {
 		edges = append(edges, portal.EdgeTask)
+	}
+	if m.shell_task != nil {
+		edges = append(edges, portal.EdgeShellTask)
 	}
 	if m.beacon != nil {
 		edges = append(edges, portal.EdgeBeacon)
@@ -10067,6 +10111,10 @@ func (m *PortalMutation) AddedIDs(name string) []ent.Value {
 	switch name {
 	case portal.EdgeTask:
 		if id := m.task; id != nil {
+			return []ent.Value{*id}
+		}
+	case portal.EdgeShellTask:
+		if id := m.shell_task; id != nil {
 			return []ent.Value{*id}
 		}
 	case portal.EdgeBeacon:
@@ -10089,7 +10137,7 @@ func (m *PortalMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *PortalMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 4)
+	edges := make([]string, 0, 5)
 	if m.removedactive_users != nil {
 		edges = append(edges, portal.EdgeActiveUsers)
 	}
@@ -10112,9 +10160,12 @@ func (m *PortalMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *PortalMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 4)
+	edges := make([]string, 0, 5)
 	if m.clearedtask {
 		edges = append(edges, portal.EdgeTask)
+	}
+	if m.clearedshell_task {
+		edges = append(edges, portal.EdgeShellTask)
 	}
 	if m.clearedbeacon {
 		edges = append(edges, portal.EdgeBeacon)
@@ -10134,6 +10185,8 @@ func (m *PortalMutation) EdgeCleared(name string) bool {
 	switch name {
 	case portal.EdgeTask:
 		return m.clearedtask
+	case portal.EdgeShellTask:
+		return m.clearedshell_task
 	case portal.EdgeBeacon:
 		return m.clearedbeacon
 	case portal.EdgeOwner:
@@ -10151,6 +10204,9 @@ func (m *PortalMutation) ClearEdge(name string) error {
 	case portal.EdgeTask:
 		m.ClearTask()
 		return nil
+	case portal.EdgeShellTask:
+		m.ClearShellTask()
+		return nil
 	case portal.EdgeBeacon:
 		m.ClearBeacon()
 		return nil
@@ -10167,6 +10223,9 @@ func (m *PortalMutation) ResetEdge(name string) error {
 	switch name {
 	case portal.EdgeTask:
 		m.ResetTask()
+		return nil
+	case portal.EdgeShellTask:
+		m.ResetShellTask()
 		return nil
 	case portal.EdgeBeacon:
 		m.ResetBeacon()

--- a/tavern/internal/ent/portal.go
+++ b/tavern/internal/ent/portal.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"realm.pub/tavern/internal/ent/beacon"
 	"realm.pub/tavern/internal/ent/portal"
+	"realm.pub/tavern/internal/ent/shelltask"
 	"realm.pub/tavern/internal/ent/task"
 	"realm.pub/tavern/internal/ent/user"
 )
@@ -28,18 +29,21 @@ type Portal struct {
 	ClosedAt time.Time `json:"closed_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PortalQuery when eager-loading is set.
-	Edges         PortalEdges `json:"edges"`
-	portal_task   *int
-	portal_beacon *int
-	portal_owner  *int
-	shell_portals *int
-	selectValues  sql.SelectValues
+	Edges             PortalEdges `json:"edges"`
+	portal_task       *int
+	portal_shell_task *int
+	portal_beacon     *int
+	portal_owner      *int
+	shell_portals     *int
+	selectValues      sql.SelectValues
 }
 
 // PortalEdges holds the relations/edges for other nodes in the graph.
 type PortalEdges struct {
 	// Task that created the portal
 	Task *Task `json:"task,omitempty"`
+	// ShellTask that created the portal
+	ShellTask *ShellTask `json:"shell_task,omitempty"`
 	// Beacon that created the portal
 	Beacon *Beacon `json:"beacon,omitempty"`
 	// User that created the portal
@@ -48,9 +52,9 @@ type PortalEdges struct {
 	ActiveUsers []*User `json:"active_users,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [4]bool
+	loadedTypes [5]bool
 	// totalCount holds the count of the edges above.
-	totalCount [4]map[string]int
+	totalCount [5]map[string]int
 
 	namedActiveUsers map[string][]*User
 }
@@ -66,12 +70,23 @@ func (e PortalEdges) TaskOrErr() (*Task, error) {
 	return nil, &NotLoadedError{edge: "task"}
 }
 
+// ShellTaskOrErr returns the ShellTask value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e PortalEdges) ShellTaskOrErr() (*ShellTask, error) {
+	if e.ShellTask != nil {
+		return e.ShellTask, nil
+	} else if e.loadedTypes[1] {
+		return nil, &NotFoundError{label: shelltask.Label}
+	}
+	return nil, &NotLoadedError{edge: "shell_task"}
+}
+
 // BeaconOrErr returns the Beacon value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e PortalEdges) BeaconOrErr() (*Beacon, error) {
 	if e.Beacon != nil {
 		return e.Beacon, nil
-	} else if e.loadedTypes[1] {
+	} else if e.loadedTypes[2] {
 		return nil, &NotFoundError{label: beacon.Label}
 	}
 	return nil, &NotLoadedError{edge: "beacon"}
@@ -82,7 +97,7 @@ func (e PortalEdges) BeaconOrErr() (*Beacon, error) {
 func (e PortalEdges) OwnerOrErr() (*User, error) {
 	if e.Owner != nil {
 		return e.Owner, nil
-	} else if e.loadedTypes[2] {
+	} else if e.loadedTypes[3] {
 		return nil, &NotFoundError{label: user.Label}
 	}
 	return nil, &NotLoadedError{edge: "owner"}
@@ -91,7 +106,7 @@ func (e PortalEdges) OwnerOrErr() (*User, error) {
 // ActiveUsersOrErr returns the ActiveUsers value or an error if the edge
 // was not loaded in eager-loading.
 func (e PortalEdges) ActiveUsersOrErr() ([]*User, error) {
-	if e.loadedTypes[3] {
+	if e.loadedTypes[4] {
 		return e.ActiveUsers, nil
 	}
 	return nil, &NotLoadedError{edge: "active_users"}
@@ -108,11 +123,13 @@ func (*Portal) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullTime)
 		case portal.ForeignKeys[0]: // portal_task
 			values[i] = new(sql.NullInt64)
-		case portal.ForeignKeys[1]: // portal_beacon
+		case portal.ForeignKeys[1]: // portal_shell_task
 			values[i] = new(sql.NullInt64)
-		case portal.ForeignKeys[2]: // portal_owner
+		case portal.ForeignKeys[2]: // portal_beacon
 			values[i] = new(sql.NullInt64)
-		case portal.ForeignKeys[3]: // shell_portals
+		case portal.ForeignKeys[3]: // portal_owner
+			values[i] = new(sql.NullInt64)
+		case portal.ForeignKeys[4]: // shell_portals
 			values[i] = new(sql.NullInt64)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -162,19 +179,26 @@ func (po *Portal) assignValues(columns []string, values []any) error {
 			}
 		case portal.ForeignKeys[1]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for edge-field portal_shell_task", value)
+			} else if value.Valid {
+				po.portal_shell_task = new(int)
+				*po.portal_shell_task = int(value.Int64)
+			}
+		case portal.ForeignKeys[2]:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
 				return fmt.Errorf("unexpected type %T for edge-field portal_beacon", value)
 			} else if value.Valid {
 				po.portal_beacon = new(int)
 				*po.portal_beacon = int(value.Int64)
 			}
-		case portal.ForeignKeys[2]:
+		case portal.ForeignKeys[3]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
 				return fmt.Errorf("unexpected type %T for edge-field portal_owner", value)
 			} else if value.Valid {
 				po.portal_owner = new(int)
 				*po.portal_owner = int(value.Int64)
 			}
-		case portal.ForeignKeys[3]:
+		case portal.ForeignKeys[4]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
 				return fmt.Errorf("unexpected type %T for edge-field shell_portals", value)
 			} else if value.Valid {
@@ -197,6 +221,11 @@ func (po *Portal) Value(name string) (ent.Value, error) {
 // QueryTask queries the "task" edge of the Portal entity.
 func (po *Portal) QueryTask() *TaskQuery {
 	return NewPortalClient(po.config).QueryTask(po)
+}
+
+// QueryShellTask queries the "shell_task" edge of the Portal entity.
+func (po *Portal) QueryShellTask() *ShellTaskQuery {
+	return NewPortalClient(po.config).QueryShellTask(po)
 }
 
 // QueryBeacon queries the "beacon" edge of the Portal entity.

--- a/tavern/internal/ent/portal/portal.go
+++ b/tavern/internal/ent/portal/portal.go
@@ -22,6 +22,8 @@ const (
 	FieldClosedAt = "closed_at"
 	// EdgeTask holds the string denoting the task edge name in mutations.
 	EdgeTask = "task"
+	// EdgeShellTask holds the string denoting the shell_task edge name in mutations.
+	EdgeShellTask = "shell_task"
 	// EdgeBeacon holds the string denoting the beacon edge name in mutations.
 	EdgeBeacon = "beacon"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
@@ -37,6 +39,13 @@ const (
 	TaskInverseTable = "tasks"
 	// TaskColumn is the table column denoting the task relation/edge.
 	TaskColumn = "portal_task"
+	// ShellTaskTable is the table that holds the shell_task relation/edge.
+	ShellTaskTable = "portals"
+	// ShellTaskInverseTable is the table name for the ShellTask entity.
+	// It exists in this package in order to avoid circular dependency with the "shelltask" package.
+	ShellTaskInverseTable = "shell_tasks"
+	// ShellTaskColumn is the table column denoting the shell_task relation/edge.
+	ShellTaskColumn = "portal_shell_task"
 	// BeaconTable is the table that holds the beacon relation/edge.
 	BeaconTable = "portals"
 	// BeaconInverseTable is the table name for the Beacon entity.
@@ -72,6 +81,7 @@ var Columns = []string{
 // table and are not defined as standalone fields in the schema.
 var ForeignKeys = []string{
 	"portal_task",
+	"portal_shell_task",
 	"portal_beacon",
 	"portal_owner",
 	"shell_portals",
@@ -131,6 +141,13 @@ func ByTaskField(field string, opts ...sql.OrderTermOption) OrderOption {
 	}
 }
 
+// ByShellTaskField orders the results by shell_task field.
+func ByShellTaskField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newShellTaskStep(), sql.OrderByField(field, opts...))
+	}
+}
+
 // ByBeaconField orders the results by beacon field.
 func ByBeaconField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -163,6 +180,13 @@ func newTaskStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(TaskInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, false, TaskTable, TaskColumn),
+	)
+}
+func newShellTaskStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ShellTaskInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, ShellTaskTable, ShellTaskColumn),
 	)
 }
 func newBeaconStep() *sqlgraph.Step {

--- a/tavern/internal/ent/portal/where.go
+++ b/tavern/internal/ent/portal/where.go
@@ -223,6 +223,29 @@ func HasTaskWith(preds ...predicate.Task) predicate.Portal {
 	})
 }
 
+// HasShellTask applies the HasEdge predicate on the "shell_task" edge.
+func HasShellTask() predicate.Portal {
+	return predicate.Portal(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, ShellTaskTable, ShellTaskColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasShellTaskWith applies the HasEdge predicate on the "shell_task" edge with a given conditions (other predicates).
+func HasShellTaskWith(preds ...predicate.ShellTask) predicate.Portal {
+	return predicate.Portal(func(s *sql.Selector) {
+		step := newShellTaskStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasBeacon applies the HasEdge predicate on the "beacon" edge.
 func HasBeacon() predicate.Portal {
 	return predicate.Portal(func(s *sql.Selector) {

--- a/tavern/internal/ent/portal_create.go
+++ b/tavern/internal/ent/portal_create.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"realm.pub/tavern/internal/ent/beacon"
 	"realm.pub/tavern/internal/ent/portal"
+	"realm.pub/tavern/internal/ent/shelltask"
 	"realm.pub/tavern/internal/ent/task"
 	"realm.pub/tavern/internal/ent/user"
 )
@@ -73,9 +74,36 @@ func (pc *PortalCreate) SetTaskID(id int) *PortalCreate {
 	return pc
 }
 
+// SetNillableTaskID sets the "task" edge to the Task entity by ID if the given value is not nil.
+func (pc *PortalCreate) SetNillableTaskID(id *int) *PortalCreate {
+	if id != nil {
+		pc = pc.SetTaskID(*id)
+	}
+	return pc
+}
+
 // SetTask sets the "task" edge to the Task entity.
 func (pc *PortalCreate) SetTask(t *Task) *PortalCreate {
 	return pc.SetTaskID(t.ID)
+}
+
+// SetShellTaskID sets the "shell_task" edge to the ShellTask entity by ID.
+func (pc *PortalCreate) SetShellTaskID(id int) *PortalCreate {
+	pc.mutation.SetShellTaskID(id)
+	return pc
+}
+
+// SetNillableShellTaskID sets the "shell_task" edge to the ShellTask entity by ID if the given value is not nil.
+func (pc *PortalCreate) SetNillableShellTaskID(id *int) *PortalCreate {
+	if id != nil {
+		pc = pc.SetShellTaskID(*id)
+	}
+	return pc
+}
+
+// SetShellTask sets the "shell_task" edge to the ShellTask entity.
+func (pc *PortalCreate) SetShellTask(s *ShellTask) *PortalCreate {
+	return pc.SetShellTaskID(s.ID)
 }
 
 // SetBeaconID sets the "beacon" edge to the Beacon entity by ID.
@@ -168,9 +196,6 @@ func (pc *PortalCreate) check() error {
 	if _, ok := pc.mutation.LastModifiedAt(); !ok {
 		return &ValidationError{Name: "last_modified_at", err: errors.New(`ent: missing required field "Portal.last_modified_at"`)}
 	}
-	if len(pc.mutation.TaskIDs()) == 0 {
-		return &ValidationError{Name: "task", err: errors.New(`ent: missing required edge "Portal.task"`)}
-	}
 	if len(pc.mutation.BeaconIDs()) == 0 {
 		return &ValidationError{Name: "beacon", err: errors.New(`ent: missing required edge "Portal.beacon"`)}
 	}
@@ -231,6 +256,23 @@ func (pc *PortalCreate) createSpec() (*Portal, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.portal_task = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pc.mutation.ShellTaskIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   portal.ShellTaskTable,
+			Columns: []string{portal.ShellTaskColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(shelltask.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.portal_shell_task = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := pc.mutation.BeaconIDs(); len(nodes) > 0 {

--- a/tavern/internal/ent/portal_query.go
+++ b/tavern/internal/ent/portal_query.go
@@ -15,6 +15,7 @@ import (
 	"realm.pub/tavern/internal/ent/beacon"
 	"realm.pub/tavern/internal/ent/portal"
 	"realm.pub/tavern/internal/ent/predicate"
+	"realm.pub/tavern/internal/ent/shelltask"
 	"realm.pub/tavern/internal/ent/task"
 	"realm.pub/tavern/internal/ent/user"
 )
@@ -27,6 +28,7 @@ type PortalQuery struct {
 	inters               []Interceptor
 	predicates           []predicate.Portal
 	withTask             *TaskQuery
+	withShellTask        *ShellTaskQuery
 	withBeacon           *BeaconQuery
 	withOwner            *UserQuery
 	withActiveUsers      *UserQuery
@@ -85,6 +87,28 @@ func (pq *PortalQuery) QueryTask() *TaskQuery {
 			sqlgraph.From(portal.Table, portal.FieldID, selector),
 			sqlgraph.To(task.Table, task.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, portal.TaskTable, portal.TaskColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryShellTask chains the current query on the "shell_task" edge.
+func (pq *PortalQuery) QueryShellTask() *ShellTaskQuery {
+	query := (&ShellTaskClient{config: pq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := pq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := pq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(portal.Table, portal.FieldID, selector),
+			sqlgraph.To(shelltask.Table, shelltask.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, portal.ShellTaskTable, portal.ShellTaskColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
 		return fromU, nil
@@ -351,6 +375,7 @@ func (pq *PortalQuery) Clone() *PortalQuery {
 		inters:          append([]Interceptor{}, pq.inters...),
 		predicates:      append([]predicate.Portal{}, pq.predicates...),
 		withTask:        pq.withTask.Clone(),
+		withShellTask:   pq.withShellTask.Clone(),
 		withBeacon:      pq.withBeacon.Clone(),
 		withOwner:       pq.withOwner.Clone(),
 		withActiveUsers: pq.withActiveUsers.Clone(),
@@ -368,6 +393,17 @@ func (pq *PortalQuery) WithTask(opts ...func(*TaskQuery)) *PortalQuery {
 		opt(query)
 	}
 	pq.withTask = query
+	return pq
+}
+
+// WithShellTask tells the query-builder to eager-load the nodes that are connected to
+// the "shell_task" edge. The optional arguments are used to configure the query builder of the edge.
+func (pq *PortalQuery) WithShellTask(opts ...func(*ShellTaskQuery)) *PortalQuery {
+	query := (&ShellTaskClient{config: pq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	pq.withShellTask = query
 	return pq
 }
 
@@ -483,14 +519,15 @@ func (pq *PortalQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Porta
 		nodes       = []*Portal{}
 		withFKs     = pq.withFKs
 		_spec       = pq.querySpec()
-		loadedTypes = [4]bool{
+		loadedTypes = [5]bool{
 			pq.withTask != nil,
+			pq.withShellTask != nil,
 			pq.withBeacon != nil,
 			pq.withOwner != nil,
 			pq.withActiveUsers != nil,
 		}
 	)
-	if pq.withTask != nil || pq.withBeacon != nil || pq.withOwner != nil {
+	if pq.withTask != nil || pq.withShellTask != nil || pq.withBeacon != nil || pq.withOwner != nil {
 		withFKs = true
 	}
 	if withFKs {
@@ -520,6 +557,12 @@ func (pq *PortalQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Porta
 	if query := pq.withTask; query != nil {
 		if err := pq.loadTask(ctx, query, nodes, nil,
 			func(n *Portal, e *Task) { n.Edges.Task = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := pq.withShellTask; query != nil {
+		if err := pq.loadShellTask(ctx, query, nodes, nil,
+			func(n *Portal, e *ShellTask) { n.Edges.ShellTask = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -582,6 +625,38 @@ func (pq *PortalQuery) loadTask(ctx context.Context, query *TaskQuery, nodes []*
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "portal_task" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (pq *PortalQuery) loadShellTask(ctx context.Context, query *ShellTaskQuery, nodes []*Portal, init func(*Portal), assign func(*Portal, *ShellTask)) error {
+	ids := make([]int, 0, len(nodes))
+	nodeids := make(map[int][]*Portal)
+	for i := range nodes {
+		if nodes[i].portal_shell_task == nil {
+			continue
+		}
+		fk := *nodes[i].portal_shell_task
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(shelltask.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "portal_shell_task" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)

--- a/tavern/internal/ent/portal_update.go
+++ b/tavern/internal/ent/portal_update.go
@@ -14,6 +14,7 @@ import (
 	"realm.pub/tavern/internal/ent/beacon"
 	"realm.pub/tavern/internal/ent/portal"
 	"realm.pub/tavern/internal/ent/predicate"
+	"realm.pub/tavern/internal/ent/shelltask"
 	"realm.pub/tavern/internal/ent/task"
 	"realm.pub/tavern/internal/ent/user"
 )
@@ -63,9 +64,36 @@ func (pu *PortalUpdate) SetTaskID(id int) *PortalUpdate {
 	return pu
 }
 
+// SetNillableTaskID sets the "task" edge to the Task entity by ID if the given value is not nil.
+func (pu *PortalUpdate) SetNillableTaskID(id *int) *PortalUpdate {
+	if id != nil {
+		pu = pu.SetTaskID(*id)
+	}
+	return pu
+}
+
 // SetTask sets the "task" edge to the Task entity.
 func (pu *PortalUpdate) SetTask(t *Task) *PortalUpdate {
 	return pu.SetTaskID(t.ID)
+}
+
+// SetShellTaskID sets the "shell_task" edge to the ShellTask entity by ID.
+func (pu *PortalUpdate) SetShellTaskID(id int) *PortalUpdate {
+	pu.mutation.SetShellTaskID(id)
+	return pu
+}
+
+// SetNillableShellTaskID sets the "shell_task" edge to the ShellTask entity by ID if the given value is not nil.
+func (pu *PortalUpdate) SetNillableShellTaskID(id *int) *PortalUpdate {
+	if id != nil {
+		pu = pu.SetShellTaskID(*id)
+	}
+	return pu
+}
+
+// SetShellTask sets the "shell_task" edge to the ShellTask entity.
+func (pu *PortalUpdate) SetShellTask(s *ShellTask) *PortalUpdate {
+	return pu.SetShellTaskID(s.ID)
 }
 
 // SetBeaconID sets the "beacon" edge to the Beacon entity by ID.
@@ -113,6 +141,12 @@ func (pu *PortalUpdate) Mutation() *PortalMutation {
 // ClearTask clears the "task" edge to the Task entity.
 func (pu *PortalUpdate) ClearTask() *PortalUpdate {
 	pu.mutation.ClearTask()
+	return pu
+}
+
+// ClearShellTask clears the "shell_task" edge to the ShellTask entity.
+func (pu *PortalUpdate) ClearShellTask() *PortalUpdate {
+	pu.mutation.ClearShellTask()
 	return pu
 }
 
@@ -187,9 +221,6 @@ func (pu *PortalUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (pu *PortalUpdate) check() error {
-	if pu.mutation.TaskCleared() && len(pu.mutation.TaskIDs()) > 0 {
-		return errors.New(`ent: clearing a required unique edge "Portal.task"`)
-	}
 	if pu.mutation.BeaconCleared() && len(pu.mutation.BeaconIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Portal.beacon"`)
 	}
@@ -242,6 +273,35 @@ func (pu *PortalUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(task.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.ShellTaskCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   portal.ShellTaskTable,
+			Columns: []string{portal.ShellTaskColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(shelltask.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.ShellTaskIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   portal.ShellTaskTable,
+			Columns: []string{portal.ShellTaskColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(shelltask.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {
@@ -404,9 +464,36 @@ func (puo *PortalUpdateOne) SetTaskID(id int) *PortalUpdateOne {
 	return puo
 }
 
+// SetNillableTaskID sets the "task" edge to the Task entity by ID if the given value is not nil.
+func (puo *PortalUpdateOne) SetNillableTaskID(id *int) *PortalUpdateOne {
+	if id != nil {
+		puo = puo.SetTaskID(*id)
+	}
+	return puo
+}
+
 // SetTask sets the "task" edge to the Task entity.
 func (puo *PortalUpdateOne) SetTask(t *Task) *PortalUpdateOne {
 	return puo.SetTaskID(t.ID)
+}
+
+// SetShellTaskID sets the "shell_task" edge to the ShellTask entity by ID.
+func (puo *PortalUpdateOne) SetShellTaskID(id int) *PortalUpdateOne {
+	puo.mutation.SetShellTaskID(id)
+	return puo
+}
+
+// SetNillableShellTaskID sets the "shell_task" edge to the ShellTask entity by ID if the given value is not nil.
+func (puo *PortalUpdateOne) SetNillableShellTaskID(id *int) *PortalUpdateOne {
+	if id != nil {
+		puo = puo.SetShellTaskID(*id)
+	}
+	return puo
+}
+
+// SetShellTask sets the "shell_task" edge to the ShellTask entity.
+func (puo *PortalUpdateOne) SetShellTask(s *ShellTask) *PortalUpdateOne {
+	return puo.SetShellTaskID(s.ID)
 }
 
 // SetBeaconID sets the "beacon" edge to the Beacon entity by ID.
@@ -454,6 +541,12 @@ func (puo *PortalUpdateOne) Mutation() *PortalMutation {
 // ClearTask clears the "task" edge to the Task entity.
 func (puo *PortalUpdateOne) ClearTask() *PortalUpdateOne {
 	puo.mutation.ClearTask()
+	return puo
+}
+
+// ClearShellTask clears the "shell_task" edge to the ShellTask entity.
+func (puo *PortalUpdateOne) ClearShellTask() *PortalUpdateOne {
+	puo.mutation.ClearShellTask()
 	return puo
 }
 
@@ -541,9 +634,6 @@ func (puo *PortalUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (puo *PortalUpdateOne) check() error {
-	if puo.mutation.TaskCleared() && len(puo.mutation.TaskIDs()) > 0 {
-		return errors.New(`ent: clearing a required unique edge "Portal.task"`)
-	}
 	if puo.mutation.BeaconCleared() && len(puo.mutation.BeaconIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Portal.beacon"`)
 	}
@@ -613,6 +703,35 @@ func (puo *PortalUpdateOne) sqlSave(ctx context.Context) (_node *Portal, err err
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(task.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.ShellTaskCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   portal.ShellTaskTable,
+			Columns: []string{portal.ShellTaskColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(shelltask.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.ShellTaskIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   portal.ShellTaskTable,
+			Columns: []string{portal.ShellTaskColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(shelltask.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/tavern/internal/ent/schema/portal.go
+++ b/tavern/internal/ent/schema/portal.go
@@ -32,8 +32,10 @@ func (Portal) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("task", Task.Type).
 			Unique().
-			Required().
 			Comment("Task that created the portal"),
+		edge.To("shell_task", ShellTask.Type).
+			Unique().
+			Comment("ShellTask that created the portal"),
 		edge.To("beacon", Beacon.Type).
 			Unique().
 			Required().

--- a/tavern/internal/graphql/schema/ent.graphql
+++ b/tavern/internal/graphql/schema/ent.graphql
@@ -2756,7 +2756,11 @@ type Portal implements Node {
   """
   Task that created the portal
   """
-  task: Task!
+  task: Task
+  """
+  ShellTask that created the portal
+  """
+  shellTask: ShellTask
   """
   Beacon that created the portal
   """
@@ -2907,6 +2911,11 @@ input PortalWhereInput {
   """
   hasTask: Boolean
   hasTaskWith: [TaskWhereInput!]
+  """
+  shell_task edge predicates
+  """
+  hasShellTask: Boolean
+  hasShellTaskWith: [ShellTaskWhereInput!]
   """
   beacon edge predicates
   """

--- a/tavern/internal/portals/mux/benchmark_test.go
+++ b/tavern/internal/portals/mux/benchmark_test.go
@@ -32,7 +32,7 @@ func BenchmarkMuxThroughput(b *testing.B) {
 
 	// Setup Portals
 	// Host Side
-	portalID, teardownCreate, err := m.CreatePortal(ctx, client, task.ID)
+	portalID, teardownCreate, err := m.CreatePortal(ctx, client, task.ID, 0)
 	require.NoError(b, err)
 	defer teardownCreate()
 

--- a/tavern/internal/portals/mux/mux_test.go
+++ b/tavern/internal/portals/mux/mux_test.go
@@ -91,7 +91,7 @@ func TestMux_CreatePortal(t *testing.T) {
 	task := client.Task.Create().SetQuest(quest).SetBeacon(b).SaveX(ctx)
 
 	// Updated call
-	portalID, teardown, err := m.CreatePortal(ctx, client, task.ID)
+	portalID, teardown, err := m.CreatePortal(ctx, client, task.ID, 0)
 	require.NoError(t, err)
 	assert.NotZero(t, portalID)
 	defer teardown()
@@ -196,4 +196,42 @@ func TestWithSubscriberBufferSize(t *testing.T) {
 	expected := 12345
 	m := New(WithSubscriberBufferSize(expected))
 	assert.Equal(t, expected, m.subs.bufferSize)
+}
+
+func TestMux_CreatePortal_ShellTask(t *testing.T) {
+	// Setup DB
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	// Setup Mux
+	m := New()
+	ctx := context.Background()
+
+	// Create User, Host, Beacon
+	u := client.User.Create().SetName("testuser").SetOauthID("oauth").SetPhotoURL("photo").SaveX(ctx)
+	h := client.Host.Create().SetName("host").SetIdentifier("ident").SetPlatform(c2pb.Host_PLATFORM_LINUX).SaveX(ctx)
+	b := client.Beacon.Create().SetName("beacon").SetTransport(c2pb.Transport_TRANSPORT_HTTP1).SetHost(h).SaveX(ctx)
+
+	// Create Shell and ShellTask
+	shell := client.Shell.Create().SetBeacon(b).SetOwner(u).SetData([]byte("")).SaveX(ctx)
+	st := client.ShellTask.Create().SetShell(shell).SetCreator(u).SetInput("test").SetStreamID("stream").SetSequenceID(1).SaveX(ctx)
+
+	// Updated call
+	portalID, teardown, err := m.CreatePortal(ctx, client, 0, st.ID)
+	require.NoError(t, err)
+	assert.NotZero(t, portalID)
+	defer teardown()
+
+	// Check DB
+	portals := client.Portal.Query().AllX(ctx)
+	require.Len(t, portals, 1)
+	p := portals[0]
+	if !p.ClosedAt.IsZero() {
+		assert.True(t, p.ClosedAt.IsZero(), "ClosedAt should be zero/nil")
+	}
+
+	// Verify Relations
+	require.Equal(t, st.ID, p.QueryShellTask().OnlyIDX(ctx))
+	require.Equal(t, b.ID, p.QueryBeacon().OnlyIDX(ctx))
+	require.Equal(t, u.ID, p.QueryOwner().OnlyIDX(ctx))
 }


### PR DESCRIPTION
This PR enables creating portals directly from a `ShellTask` context, in addition to the existing `Task` context. This aligns with recent changes in the context system where `ShellTask`s are first-class entities for execution.

Key changes:
- `tavern/internal/ent/schema/portal.go`: Updated schema to support `ShellTask` relation.
- `tavern/internal/portals/mux/mux_create.go`: Updated logic to handle `shellTaskID`.
- `tavern/internal/c2/api_create_portal.go`: Updated gRPC handler to support `ShellTaskContext` properly.
- `tavern/internal/portals/mux/mux_test.go`: Added `TestMux_CreatePortal_ShellTask`.

---
*PR created automatically by Jules for task [13250956419771946780](https://jules.google.com/task/13250956419771946780) started by @KCarretto*