### PR TITLE
Fix portal tests by adding JWT to TaskContext

### DIFF
--- a/tavern/internal/portals/benchmark_test.go
+++ b/tavern/internal/portals/benchmark_test.go
@@ -140,7 +140,12 @@ func BenchmarkPortalThroughput(b *testing.B) {
 
 	// Send initial request with TaskID
 	err = agentStream.Send(&c2pb.CreatePortalRequest{
-		Context: &c2pb.CreatePortalRequest_TaskContext{TaskContext: &c2pb.TaskContext{TaskId: int64(taskEnt.ID)}},
+		Context: &c2pb.CreatePortalRequest_TaskContext{
+			TaskContext: &c2pb.TaskContext{
+				TaskId: int64(taskEnt.ID),
+				Jwt:    generateJWT(b, testPrivKey),
+			},
+		},
 	})
 	require.NoError(b, err)
 

--- a/tavern/internal/portals/integration_test.go
+++ b/tavern/internal/portals/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/pubsub"
 	_ "gocloud.dev/pubsub/mempubsub"
@@ -37,6 +38,20 @@ type TestEnv struct {
 	PortalClient portalpb.PortalClient
 	Close        func()
 	EntClient    *ent.Client
+	PrivKey      ed25519.PrivateKey
+}
+
+func generateJWT(t testing.TB, privKey ed25519.PrivateKey) string {
+	claims := jwt.MapClaims{
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(1 * time.Hour).Unix(), // Token expires in 1 hour
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	signedToken, err := token.SignedString(privKey)
+	require.NoError(t, err)
+
+	return signedToken
 }
 
 func SetupTestEnv(t *testing.T) *TestEnv {
@@ -97,6 +112,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 		C2Client:     c2Client,
 		PortalClient: portalClient,
 		EntClient:    entClient,
+		PrivKey:      testPrivKey,
 		Close: func() {
 			err := conn.Close()
 			if err != nil {
@@ -194,7 +210,12 @@ func TestPortalIntegration(t *testing.T) {
 
 	// Send initial registration message
 	err = c2Stream.Send(&c2pb.CreatePortalRequest{
-		Context: &c2pb.CreatePortalRequest_TaskContext{TaskContext: &c2pb.TaskContext{TaskId: int64(taskID)}},
+		Context: &c2pb.CreatePortalRequest_TaskContext{
+			TaskContext: &c2pb.TaskContext{
+				TaskId: int64(taskID),
+				Jwt:    generateJWT(t, env.PrivKey),
+			},
+		},
 	})
 	require.NoError(t, err)
 

--- a/tavern/internal/portals/portal_close_test.go
+++ b/tavern/internal/portals/portal_close_test.go
@@ -28,7 +28,12 @@ func TestPortalClose(t *testing.T) {
 
 	// Send initial registration message
 	err = c2Stream.Send(&c2pb.CreatePortalRequest{
-		Context: &c2pb.CreatePortalRequest_TaskContext{TaskContext: &c2pb.TaskContext{TaskId: int64(taskID)}},
+		Context: &c2pb.CreatePortalRequest_TaskContext{
+			TaskContext: &c2pb.TaskContext{
+				TaskId: int64(taskID),
+				Jwt:    generateJWT(t, env.PrivKey),
+			},
+		},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixed failing Go tests in `tavern/internal/portals` by ensuring that `CreatePortalRequest` messages include a valid signed JWT in their `TaskContext`. The server-side validation now enforces this, so tests were updated to generate and attach these tokens using the test environment's private key.

Changes:
- Modified `TestEnv` in `tavern/internal/portals/integration_test.go` to store `PrivKey`.
- Added `generateJWT` helper function.
- Updated `TestPortalIntegration`, `TestPortalClose`, and `BenchmarkPortalThroughput` to usage the new helper.

---
*PR created automatically by Jules for task [13053957921255342923](https://jules.google.com/task/13053957921255342923) started by @KCarretto*