### PR TITLE
Fix Reverse Shell E2E test shutdown race condition

### DIFF
--- a/tavern/internal/c2/api_reverse_shell.go
+++ b/tavern/internal/c2/api_reverse_shell.go
@@ -67,6 +67,8 @@ func (srv *Server) resolveTaskFromReverseShell(ctx context.Context, msg *c2pb.Re
 func (srv *Server) ReverseShell(gstream c2pb.C2_ReverseShellServer) error {
 	// Setup Context
 	ctx := gstream.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// Get initial message for registration
 	registerMsg, err := gstream.Recv()
@@ -193,6 +195,7 @@ func (srv *Server) ReverseShell(gstream c2pb.C2_ReverseShellServer) error {
 
 	// Send Output (to pubsub)
 	err = sendShellOutput(ctx, shellID, gstream, pubsubStream, srv.mux)
+	cancel()
 
 	wg.Wait()
 

--- a/tavern/internal/c2/reverse_shell_e2e_test.go
+++ b/tavern/internal/c2/reverse_shell_e2e_test.go
@@ -168,4 +168,17 @@ func TestReverseShell_E2E(t *testing.T) {
 	grpcResp, err := gRPCStream.Recv()
 	require.NoError(t, err)
 	assert.Equal(t, wsMsgToSend, grpcResp.Data)
+
+	// Close the stream
+	err = gRPCStream.CloseSend()
+	require.NoError(t, err)
+
+	// Wait for the websocket to close
+	ws.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		_, _, err := ws.ReadMessage()
+		if err != nil {
+			break
+		}
+	}
 }


### PR DESCRIPTION
This change fixes a race condition and potential deadlock in the Reverse Shell E2E test. Previously, the test would often log `pubsub: Topic has been Shutdown` because the server-side handler was still trying to publish cleanup messages after the test had already shut down the pubsub topic. This was caused by the server handler's `wg.Wait()` blocking indefinitely (or until connection drop) because the background goroutines were not being signaled to stop when the client finished sending output. The fix introduces a cancellable context to coordinate the shutdown of these goroutines and updates the test to perform a graceful close sequence.

---
*PR created automatically by Jules for task [7602734343442001450](https://jules.google.com/task/7602734343442001450) started by @KCarretto*