### PR TITLE
Fix e2e test failure by updating REPL prompt to match expectation

### DIFF
--- a/implants/imix/src/shell/repl.rs
+++ b/implants/imix/src/shell/repl.rs
@@ -87,7 +87,7 @@ fn render<W: Write>(
     }
 
     let state = repl.get_render_state();
-    let prompt = "> ";
+    let prompt = ">>> ";
     writer.write_all(prompt.as_bytes())?;
     writer.write_all(state.buffer.as_bytes())?;
 


### PR DESCRIPTION
The end-to-end test `tests/repl.spec.ts` was failing because it expected the shell prompt to be `>>>` but received `> `.
This PR updates the `imix` agent's REPL implementation in `implants/imix/src/shell/repl.rs` to use `>>> ` as the prompt.
This ensures consistency with the test expectation and likely with the intended UI design (since `ShellV2` also defaults to `>>> `).
Verified by compiling the `imix` crate successfully.

---
*PR created automatically by Jules for task [5406049458582450840](https://jules.google.com/task/5406049458582450840) started by @KCarretto*