### PR TITLE
fix(www): allow committing build artifacts and simplify embed directive

### DIFF
--- a/tavern/internal/www/.gitignore
+++ b/tavern/internal/www/.gitignore
@@ -18,3 +18,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Allow build files
+!/build

--- a/tavern/internal/www/http.go
+++ b/tavern/internal/www/http.go
@@ -15,9 +15,7 @@ type Handler struct {
 
 // Content embedded from the application's build directory, includes the latest build of the UI.
 //
-//go:embed build/*.png build/*.html build/*.json build/*.txt build/*.ico
-//go:embed build/static/*
-//go:embed build/wasm/*
+//go:embed build
 var Content embed.FS
 
 // ServeHTTP provides the Tavern UI, if the requested file does not exist it will serve index.html


### PR DESCRIPTION
This PR fixes a recurring build issue where `go build` fails due to missing or mismatched frontend build artifacts.

Changes:
1.  **`tavern/internal/www/.gitignore`**: Added `!/build` to ensure the `build` directory is tracked by git. This allows the frontend artifacts to be committed, so `go build` works out-of-the-box without requiring `npm run build` in fresh checkouts.
2.  **`tavern/internal/www/http.go`**: Changed the `//go:embed` directive from a list of glob patterns (`build/*.html`, `build/*.png`, etc.) to `//go:embed build`. This recursively embeds the entire `build` directory, which is simpler and more robust (e.g., it now includes `site.webmanifest` which was previously missed, and won't fail if `.ico` files are absent).

Verified by running `go build ./tavern` successfully.


---
*PR created automatically by Jules for task [15740604039805952117](https://jules.google.com/task/15740604039805952117) started by @KCarretto*