### PR TITLE
Enable imix compilation on Solaris

### DIFF
--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -38,13 +38,15 @@ eldritch = { workspace = true, features = ["std", "stdlib"] }
 eldritch-agent = { workspace = true }
 transport = { workspace = true }
 pb = { workspace = true, features = ["imix"] }
-portable-pty = { workspace = true }
 rust-embed = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 rand = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-service = { workspace = true }
+
+[target.'cfg(not(target_os = "solaris"))'.dependencies]
+portable-pty = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 static_vcruntime = { workspace = true }

--- a/implants/imix/src/shell/pty.rs
+++ b/implants/imix/src/shell/pty.rs
@@ -1,13 +1,18 @@
 use anyhow::Result;
 use eldritch_agent::Context;
+#[cfg(not(target_os = "solaris"))]
 use pb::c2::{ReverseShellMessageKind, ReverseShellRequest, reverse_shell_request};
+#[cfg(not(target_os = "solaris"))]
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+#[cfg(not(target_os = "solaris"))]
 use std::io::{Read, Write};
 use transport::Transport;
 
 #[cfg(not(target_os = "windows"))]
+#[cfg(not(target_os = "solaris"))]
 use std::path::Path;
 
+#[cfg(not(target_os = "solaris"))]
 pub async fn run_reverse_shell_pty<T: Transport>(
     context: Context,
     cmd: Option<String>,
@@ -204,4 +209,14 @@ pub async fn run_reverse_shell_pty<T: Transport>(
     #[cfg(debug_assertions)]
     log::info!("stopping reverse_shell_pty");
     Ok(())
+}
+
+#[cfg(target_os = "solaris")]
+pub async fn run_reverse_shell_pty<T: Transport>(
+    _context: Context,
+    _cmd: Option<String>,
+    _transport: T,
+) -> Result<()> {
+    use anyhow::anyhow;
+    Err(anyhow!("Reverse shell (PTY) is not supported on Solaris"))
 }


### PR DESCRIPTION
The `implants/imix` crate failed to compile on Solaris because the `portable-pty` dependency (and potentially its native PTY implementation) is not supported on that platform.

To resolve this, I have:
1.  Updated `implants/imix/Cargo.toml` to make `portable-pty` a target-specific dependency, excluded for `target_os = "solaris"`.
2.  Updated `implants/imix/src/shell/pty.rs` to conditionally compile the PTY-based reverse shell implementation.
3.  Added a fallback stub for `run_reverse_shell_pty` on Solaris that returns a descriptive error.

Verification:
- Ran `cargo check -p imix` on Linux (simulating non-Solaris build) to ensure no regressions.
- Ran `cargo test -p imix` on Linux to verify functionality remains intact for supported platforms.
- Code review confirmed the approach is correct and safe.

---
*PR created automatically by Jules for task [18056498314924685535](https://jules.google.com/task/18056498314924685535) started by @KCarretto*