### PR TITLE
[AI] Update Dependency - regex

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -105,7 +105,7 @@ prost = "0.12"
 prost-types = "0.12"
 rand = "0.8.5"
 rand_chacha = { version = "0.3.1", default-features = false, features = ["std"]}
-regex = { version = "1.5.5", default-features = false}
+regex = { version = "1.12.3", default-features = false}
 reqwest = { version = "0.12.15", default-features = false }
 russh = "0.37.1"
 russh-sftp = "=2.0.8" # `thiserror` dependcy in older versions causes downstream issues in other libraries.


### PR DESCRIPTION
Updates the regex dependency in implants/Cargo.toml from 1.5.5 to 1.12.3.
This brings in significant performance improvements and bug fixes while
maintaining the default-features = false configuration.

Build and tests verified locally.
Cargo.lock is ignored by repository configuration and thus not included.

---
*PR created automatically by Jules for task [4505733928145361323](https://jules.google.com/task/4505733928145361323) started by @KCarretto*