### PR TITLE
Fix type mismatch in eldritch-libreport screenshot reporting

### DIFF
--- a/implants/lib/eldritch/stdlib/eldritch-libreport/src/std/screenshot_impl.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libreport/src/std/screenshot_impl.rs
@@ -58,7 +58,10 @@ pub fn screenshot(agent: Arc<dyn Agent>, context: Context) -> Result<(), String>
             kind: c2::ReportFileKind::Screenshot as i32,
         };
 
-        agent.report_file(req).map_err(|e| e.to_string())?;
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(req).map_err(|e| e.to_string())?;
+        drop(tx);
+        agent.report_file(rx).map_err(|e| e.to_string())?;
     }
 
     Ok(())


### PR DESCRIPTION
This PR fixes a compilation error in the `eldritch-libreport` crate where `agent.report_file` was being called with a `ReportFileRequest` instead of a `std::sync::mpsc::Receiver<ReportFileRequest>`. I've updated the code to create a channel, send the request, and pass the receiver to the method.

---
*PR created automatically by Jules for task [7522256388715911428](https://jules.google.com/task/7522256388715911428) started by @hulto*