### PR TITLE
Fix implants DNS manual fallback logic

### DIFF
--- a/implants/lib/transport/src/dns_resolver.rs
+++ b/implants/lib/transport/src/dns_resolver.rs
@@ -8,6 +8,7 @@ pub mod doh {
     use hickory_resolver::config::{
         NameServerConfig, Protocol, ResolverConfig, ResolverOpts,
     };
+    use hickory_resolver::Name as HickoryName;
     use hickory_resolver::TokioAsyncResolver;
     use hyper_legacy::client::connect::dns::Name;
     use hyper_legacy::client::HttpConnector;
@@ -32,8 +33,10 @@ pub mod doh {
         System, // Use system DNS configuration
     }
 
-    pub(crate) fn parse_resolv_conf(content: &str) -> Vec<SocketAddr> {
+    pub(crate) fn parse_resolv_conf(content: &str) -> (Vec<SocketAddr>, Vec<String>) {
         let mut addrs = Vec::new();
+        let mut search = Vec::new();
+
         for line in content.lines() {
             let line = line.trim();
             if line.starts_with("nameserver") {
@@ -45,9 +48,19 @@ pub mod doh {
                         addrs.push(SocketAddr::new(ip, 53));
                     }
                 }
+            } else if line.starts_with("search") {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() >= 2 {
+                    search = parts[1..].iter().map(|s| s.to_string()).collect();
+                }
+            } else if line.starts_with("domain") {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() >= 2 {
+                    search = vec![parts[1].to_string()];
+                }
             }
         }
-        addrs
+        (addrs, search)
     }
 
     impl DohProvider {
@@ -66,12 +79,14 @@ pub mod doh {
                                 e
                             );
 
-                            let mut config = ResolverConfig::new();
                             let mut nameservers = Vec::new();
+                            let mut search = Vec::new();
 
                             // Try to read /etc/resolv.conf manually
                             if let Ok(content) = std::fs::read_to_string("/etc/resolv.conf") {
-                                nameservers = parse_resolv_conf(&content);
+                                let (ns, s) = parse_resolv_conf(&content);
+                                nameservers = ns;
+                                search = s;
                             }
 
                             if nameservers.is_empty() {
@@ -79,15 +94,37 @@ pub mod doh {
                                 nameservers.push("1.1.1.1:53".parse().unwrap());
                                 nameservers.push("8.8.8.8:53".parse().unwrap());
                             } else {
-                                log::info!("Manual parsing found {} nameservers.", nameservers.len());
+                                log::info!(
+                                    "Manual parsing found {} nameservers and {} search domains.",
+                                    nameservers.len(),
+                                    search.len()
+                                );
                             }
 
+                            let mut ns_config_group = Vec::new();
                             for ns in nameservers {
-                                config.add_name_server(NameServerConfig::new(ns, Protocol::Udp));
-                                config.add_name_server(NameServerConfig::new(ns, Protocol::Tcp));
+                                ns_config_group
+                                    .push(NameServerConfig::new(ns, Protocol::Udp));
+                                ns_config_group
+                                    .push(NameServerConfig::new(ns, Protocol::Tcp));
                             }
 
-                            Ok(config)
+                            let search_list: Vec<HickoryName> = search
+                                .iter()
+                                .filter_map(|s| {
+                                    use std::str::FromStr;
+                                    HickoryName::from_str(s).ok()
+                                })
+                                .collect();
+
+                            let domain = search_list.first().cloned();
+
+                            // Use from_parts to fully construct the config with search domains
+                            Ok(ResolverConfig::from_parts(
+                                domain,
+                                search_list,
+                                ns_config_group,
+                            ))
                         }
                     }
                 }
@@ -298,10 +335,42 @@ nameserver 8.8.8.8
 nameserver 1.1.1.1
 unknown_directive foo bar
 nameserver invalid_ip
+search corp.local internal.net
 "#;
-        let addrs = parse_resolv_conf(content);
+        let (addrs, search) = parse_resolv_conf(content);
         assert_eq!(addrs.len(), 2);
         assert_eq!(addrs[0], SocketAddr::from_str("8.8.8.8:53").unwrap());
         assert_eq!(addrs[1], SocketAddr::from_str("1.1.1.1:53").unwrap());
+
+        assert_eq!(search.len(), 2);
+        assert_eq!(search[0], "corp.local");
+        assert_eq!(search[1], "internal.net");
+    }
+
+    #[cfg(feature = "doh")]
+    #[test]
+    fn test_parse_resolv_conf_domain() {
+        let content = r#"
+nameserver 8.8.8.8
+domain example.com
+"#;
+        let (_, search) = parse_resolv_conf(content);
+        assert_eq!(search.len(), 1);
+        assert_eq!(search[0], "example.com");
+    }
+
+    #[cfg(feature = "doh")]
+    #[test]
+    fn test_parse_resolv_conf_precedence() {
+        // Last one wins
+        let content = r#"
+search old.search
+domain example.com
+search new.search another.search
+"#;
+        let (_, search) = parse_resolv_conf(content);
+        assert_eq!(search.len(), 2);
+        assert_eq!(search[0], "new.search");
+        assert_eq!(search[1], "another.search");
     }
 }


### PR DESCRIPTION
Implements manual parsing of `/etc/resolv.conf` when `hickory-resolver` fails to parse it. This ensures valid nameservers are used even if the file contains invalid directives. Also adds both UDP and TCP protocols for fallback servers.

---
*PR created automatically by Jules for task [7783352151942906106](https://jules.google.com/task/7783352151942906106) started by @Cictrone*