### PR TITLE
Enable click selection for shell autocomplete

### DIFF
--- a/tavern/internal/www/src/pages/shellv2/components/ShellCompletions.tsx
+++ b/tavern/internal/www/src/pages/shellv2/components/ShellCompletions.tsx
@@ -25,9 +25,10 @@ interface ShellCompletionsProps {
   show: boolean;
   pos: { x: number; y: number };
   index: number;
+  onCompletionSelect: (completion: string) => void;
 }
 
-const ShellCompletions: React.FC<ShellCompletionsProps> = ({ completions, show, pos, index }) => {
+const ShellCompletions: React.FC<ShellCompletionsProps> = ({ completions, show, pos, index, onCompletionSelect }) => {
   const completionsListRef = useRef<HTMLUListElement>(null);
   const [hoveredDoc, setHoveredDoc] = useState<{ sig: string, desc: string, x: number, y: number } | null>(null);
 
@@ -90,6 +91,11 @@ const ShellCompletions: React.FC<ShellCompletionsProps> = ({ completions, show, 
                     }
                 }}
                 onMouseLeave={() => setHoveredDoc(null)}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onCompletionSelect(c);
+                }}
                 >
                 <span>{c}</span>
                 {doc && <Info size={14} style={{ marginLeft: 8 }} />}

--- a/tavern/internal/www/src/pages/shellv2/components/ShellTerminal.tsx
+++ b/tavern/internal/www/src/pages/shellv2/components/ShellTerminal.tsx
@@ -16,6 +16,7 @@ interface ShellTerminalProps {
     signature: string;
     description: string;
   };
+  onCompletionSelect: (completion: string) => void;
 }
 
 const ShellTerminal: React.FC<ShellTerminalProps> = ({
@@ -25,7 +26,8 @@ const ShellTerminal: React.FC<ShellTerminalProps> = ({
   completionPos,
   completionIndex,
   onMouseMove,
-  tooltipState
+  tooltipState,
+  onCompletionSelect
 }) => {
   return (
     <div className="flex-grow rounded overflow-hidden relative border border-[#333]">
@@ -39,6 +41,7 @@ const ShellTerminal: React.FC<ShellTerminalProps> = ({
         show={showCompletions}
         pos={completionPos}
         index={completionIndex}
+        onCompletionSelect={onCompletionSelect}
       />
       <DocTooltip
           signature={tooltipState.signature}

--- a/tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts
+++ b/tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "xterm-addon-fit";
 import "@xterm/xterm/css/xterm.css";
@@ -82,6 +82,7 @@ export const useShellTerminal = (
             };
         }
     }, [isLateCheckin]);
+
     const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
         if (!termInstance.current || !termRef.current) return;
 
@@ -170,6 +171,113 @@ export const useShellTerminal = (
         }
     };
 
+    // Define redrawLine early so it can be used by adapter callback
+    const redrawLine = useCallback(() => {
+        const term = termInstance.current;
+        if (!term) return;
+        const state = shellState.current;
+
+        let contentToWrite = "";
+        let contentToDisplay = "";
+        let cursorIndex = 0;
+
+        if (state.isSearching) {
+            const prompt = `(reverse-i-search)'${state.searchQuery}': `;
+            let match = "";
+            if (state.searchQuery) {
+                // Simple search backwards
+                for (let i = state.history.length - 1; i >= 0; i--) {
+                    if (state.history[i].includes(state.searchQuery)) {
+                        match = state.history[i];
+                        break;
+                    }
+                }
+            }
+            contentToWrite = prompt + match;
+            contentToDisplay = contentToWrite;
+            // In search mode, cursor is typically at the end of the match
+            cursorIndex = contentToWrite.length;
+        } else {
+            contentToWrite = state.prompt + state.inputBuffer;
+            contentToDisplay = state.prompt + highlightPythonSyntax(state.inputBuffer);
+            cursorIndex = state.prompt.length + state.cursorPos;
+        }
+
+        // Calculate rows based on newlines
+        const rows = contentToWrite.split('\n').length - 1;
+
+        // Move up to start of previous rendering (regardless of mode)
+        const prevRows = lastBufferHeight.current;
+        if (prevRows > 0) {
+            term.write(`\x1b[${prevRows}A`);
+        }
+
+        // Clear everything below
+        term.write("\r\x1b[J");
+
+        // Write new content, ensuring newlines are carriage-return + newline
+        term.write(contentToDisplay.replace(/\n/g, "\r\n"));
+
+        // Update last height
+        lastBufferHeight.current = rows;
+
+        // Move cursor to correct position
+        if (!state.isSearching) {
+            // Calculate cursor position in terms of rows/cols relative to start
+            const prefix = contentToWrite.slice(0, cursorIndex);
+            const cursorRow = prefix.split('\n').length - 1;
+            const cursorCol = prefix.split('\n').pop()?.length || 0;
+
+            // Current position after write is at end of content
+            const totalRows = rows;
+            // We need to move UP from end to cursorRow
+            const moveUp = totalRows - cursorRow;
+            if (moveUp > 0) {
+                term.write(`\x1b[${moveUp}A`);
+            }
+
+            term.write("\r"); // Go to start of line
+            if (cursorCol > 0) {
+                term.write(`\x1b[${cursorCol}C`);
+            }
+        }
+    }, []);
+
+    const updateCompletionsUI = useCallback((list: string[], start: number, show: boolean, index: number) => {
+        setCompletions(list);
+        setCompletionStart(start);
+        setShowCompletions(show);
+        setCompletionIndex(index);
+        completionsRef.current = { list, start, show, index };
+
+        if (show && termInstance.current) {
+            // Calculate position
+            const cursorX = termInstance.current.buffer.active.cursorX;
+            const cursorY = termInstance.current.buffer.active.cursorY;
+            const charWidth = 9;
+            const charHeight = 17;
+            setCompletionPos({
+                x: cursorX * charWidth + 20, // + padding
+                y: cursorY * charHeight + 40 // + header/padding
+            });
+        }
+    }, []);
+
+    const applyCompletion = useCallback((completion: string) => {
+        const state = shellState.current;
+        const start = completionsRef.current.start;
+        // Replace from start to cursorPos with completion
+        // Ensure start is valid
+        if (start >= 0 && start <= state.cursorPos) {
+            const prefix = state.inputBuffer.slice(0, start);
+            const suffix = state.inputBuffer.slice(state.cursorPos);
+            state.inputBuffer = prefix + completion + suffix;
+            state.cursorPos = start + completion.length;
+            redrawLine();
+        }
+        updateCompletionsUI([], 0, false, 0);
+    }, [redrawLine, updateCompletionsUI]);
+
     useEffect(() => {
         if (!termRef.current || loading) return;
 
@@ -216,78 +324,6 @@ export const useShellTerminal = (
         window.addEventListener("resize", handleResize);
 
         termInstance.current.write("Eldritch v0.3.0\r\n");
-
-        // Define redrawLine early so it can be used by adapter callback
-        const redrawLine = () => {
-            const term = termInstance.current;
-            if (!term) return;
-            const state = shellState.current;
-
-            let contentToWrite = "";
-            let contentToDisplay = "";
-            let cursorIndex = 0;
-
-            if (state.isSearching) {
-                const prompt = `(reverse-i-search)'${state.searchQuery}': `;
-                let match = "";
-                if (state.searchQuery) {
-                    // Simple search backwards
-                    for (let i = state.history.length - 1; i >= 0; i--) {
-                        if (state.history[i].includes(state.searchQuery)) {
-                            match = state.history[i];
-                            break;
-                        }
-                    }
-                }
-                contentToWrite = prompt + match;
-                contentToDisplay = contentToWrite;
-                // In search mode, cursor is typically at the end of the match
-                cursorIndex = contentToWrite.length;
-            } else {
-                contentToWrite = state.prompt + state.inputBuffer;
-                contentToDisplay = state.prompt + highlightPythonSyntax(state.inputBuffer);
-                cursorIndex = state.prompt.length + state.cursorPos;
-            }
-
-            // Calculate rows based on newlines
-            const rows = contentToWrite.split('\n').length - 1;
-
-            // Move up to start of previous rendering (regardless of mode)
-            const prevRows = lastBufferHeight.current;
-            if (prevRows > 0) {
-                term.write(`\x1b[${prevRows}A`);
-            }
-
-            // Clear everything below
-            term.write("\r\x1b[J");
-
-            // Write new content, ensuring newlines are carriage-return + newline
-            term.write(contentToDisplay.replace(/\n/g, "\r\n"));
-
-            // Update last height
-            lastBufferHeight.current = rows;
-
-            // Move cursor to correct position
-            if (!state.isSearching) {
-                // Calculate cursor position in terms of rows/cols relative to start
-                const prefix = contentToWrite.slice(0, cursorIndex);
-                const cursorRow = prefix.split('\n').length - 1;
-                const cursorCol = prefix.split('\n').pop()?.length || 0;
-
-                // Current position after write is at end of content
-                const totalRows = rows;
-                // We need to move UP from end to cursorRow
-                const moveUp = totalRows - cursorRow;
-                if (moveUp > 0) {
-                    term.write(`\x1b[${moveUp}A`);
-                }
-
-                term.write("\r"); // Go to start of line
-                if (cursorCol > 0) {
-                    term.write(`\x1b[${cursorCol}C`);
-                }
-            }
-        };
 
         const scheme = window.location.protocol === "https:" ? "wss" : "ws";
         const url = `${scheme}://${window.location.host}/shellv2/ws?shell_id=${shellId}`;
@@ -355,41 +391,6 @@ export const useShellTerminal = (
         });
 
         adapter.current.init();
-
-        const updateCompletionsUI = (list: string[], start: number, show: boolean, index: number) => {
-            setCompletions(list);
-            setCompletionStart(start);
-            setShowCompletions(show);
-            setCompletionIndex(index);
-            completionsRef.current = { list, start, show, index };
-
-            if (show && termInstance.current) {
-                // Calculate position
-                const cursorX = termInstance.current.buffer.active.cursorX;
-                const cursorY = termInstance.current.buffer.active.cursorY;
-                const charWidth = 9;
-                const charHeight = 17;
-                setCompletionPos({
-                    x: cursorX * charWidth + 20, // + padding
-                    y: cursorY * charHeight + 40 // + header/padding
-                });
-            }
-        };
-
-        const applyCompletion = (completion: string) => {
-            const state = shellState.current;
-            const start = completionsRef.current.start;
-            // Replace from start to cursorPos with completion
-            // Ensure start is valid
-            if (start >= 0 && start <= state.cursorPos) {
-                const prefix = state.inputBuffer.slice(0, start);
-                const suffix = state.inputBuffer.slice(state.cursorPos);
-                state.inputBuffer = prefix + completion + suffix;
-                state.cursorPos = start + completion.length;
-                redrawLine();
-            }
-            updateCompletionsUI([], 0, false, 0);
-        };
 
         termInstance.current.onData((data) => {
             // Check for late checkin and block input
@@ -699,7 +700,7 @@ export const useShellTerminal = (
             adapter.current?.close();
             termInstance.current?.dispose();
         };
-    }, [shellId, loading, error, shellData, setPortalId]);
+    }, [shellId, loading, error, shellData, setPortalId, redrawLine, updateCompletionsUI, applyCompletion]);
 
     return {
         termRef,
@@ -709,6 +710,7 @@ export const useShellTerminal = (
         completionPos,
         completionIndex,
         handleMouseMove,
-        tooltipState
+        tooltipState,
+        handleCompletionSelect: applyCompletion
     };
 };

--- a/tavern/internal/www/src/pages/shellv2/index.tsx
+++ b/tavern/internal/www/src/pages/shellv2/index.tsx
@@ -31,7 +31,8 @@ const ShellV2 = () => {
         completionPos,
         completionIndex,
         handleMouseMove,
-        tooltipState
+        tooltipState,
+        handleCompletionSelect
     } = useShellTerminal(shellId, loading, error, shellData, setPortalId, isLateCheckin);
 
     if (connectionError) {
@@ -59,6 +60,7 @@ const ShellV2 = () => {
                     completionIndex={completionIndex}
                     onMouseMove={handleMouseMove}
                     tooltipState={tooltipState}
+                    onCompletionSelect={handleCompletionSelect}
                 />
 
                 <ShellStatusBar


### PR DESCRIPTION
- Refactored `tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts` to extract `redrawLine`, `updateCompletionsUI`, and `applyCompletion` into `useCallback` hooks.
- Updated `tavern/internal/www/src/pages/shellv2/components/ShellCompletions.tsx` to handle click events on completion items.
- Updated `tavern/internal/www/src/pages/shellv2/components/ShellTerminal.tsx` and `tavern/internal/www/src/pages/shellv2/index.tsx` to pass the selection handler down the component tree.
- Manually verified code changes and attempted frontend verification (hampered by environment limitations).

---
*PR created automatically by Jules for task [3440963881204362560](https://jules.google.com/task/3440963881204362560) started by @KCarretto*