### PR TITLE
Fix SQLite table lock errors in tavern integration tests

### DIFF
--- a/tavern/internal/http/shell/integration_test.go
+++ b/tavern/internal/http/shell/integration_test.go
@@ -47,7 +47,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 	ctx := context.Background()
 
 	// 1. Setup DB
-	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1", uuid.NewString())
+	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1&_busy_timeout=10000", uuid.NewString())
 	entClient := enttest.Open(t, "sqlite3", dsn)
 
 	// 2. Setup Portal Mux

--- a/tavern/internal/portals/benchmark_test.go
+++ b/tavern/internal/portals/benchmark_test.go
@@ -42,7 +42,7 @@ func newBufListener(sz int) *bufListener {
 
 func BenchmarkPortalThroughput(b *testing.B) {
 	// 1. Setup DB
-	client := enttest.Open(b, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.Open(b, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1&_busy_timeout=10000")
 	defer client.Close()
 
 	ctx := context.Background()

--- a/tavern/internal/portals/integration_test.go
+++ b/tavern/internal/portals/integration_test.go
@@ -58,7 +58,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 	ctx := context.Background()
 
 	// 1. Setup DB
-	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1", t.Name())
+	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1&_busy_timeout=10000", t.Name())
 	entClient := enttest.Open(t, "sqlite3", dsn)
 
 	// 2. Setup Portal Mux (In-Memory)

--- a/tavern/internal/portals/mux/benchmark_test.go
+++ b/tavern/internal/portals/mux/benchmark_test.go
@@ -14,7 +14,7 @@ import (
 
 func BenchmarkMuxThroughput(b *testing.B) {
 	// Setup DB
-	client := enttest.Open(b, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.Open(b, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1&_busy_timeout=10000")
 	defer client.Close()
 
 	// Setup Mux

--- a/tavern/internal/portals/mux/mux_test.go
+++ b/tavern/internal/portals/mux/mux_test.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -74,7 +75,8 @@ func TestMux_InMemory(t *testing.T) {
 
 func TestMux_CreatePortal(t *testing.T) {
 	// Setup DB
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1&_busy_timeout=10000", t.Name())
+	client := enttest.Open(t, "sqlite3", dsn)
 	defer client.Close()
 
 	// Setup Mux
@@ -200,7 +202,8 @@ func TestWithSubscriberBufferSize(t *testing.T) {
 
 func TestMux_CreatePortal_ShellTask(t *testing.T) {
 	// Setup DB
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1&_busy_timeout=10000", t.Name())
+	client := enttest.Open(t, "sqlite3", dsn)
 	defer client.Close()
 
 	// Setup Mux


### PR DESCRIPTION
This change addresses the "table lock" errors causing flaky tests in `tavern/internal/http/shell` and `tavern/internal/portals`. The fix involves adding `_busy_timeout=10000` to the SQLite connection strings in integration and benchmark tests, allowing the driver to retry when the database is locked. Additionally, `tavern/internal/portals/mux/mux_test.go` was updated to use unique in-memory database names for each test case, isolating them and preventing contention.


---
*PR created automatically by Jules for task [8258895298285432105](https://jules.google.com/task/8258895298285432105) started by @KCarretto*