### PR TITLE
feat(tomes): Parse run_on_schedule from metadata.yml

### DIFF
--- a/tavern/tomes/git.go
+++ b/tavern/tomes/git.go
@@ -240,6 +240,7 @@ func (importer *GitImporter) importFromGitTree(ctx context.Context, repo *git.Re
 		SetParamDefs(string(paramdefs)).
 		SetSupportModel(tome.SupportModelCOMMUNITY).
 		SetTactic(tome.Tactic(metadata.Tactic)).
+		SetRunOnSchedule(metadata.RunOnSchedule).
 		SetEldritch(eldritch).
 		SetRepository(entRepo).
 		AddAssetIDs(tomeFileIDs...).

--- a/tavern/tomes/git_test.go
+++ b/tavern/tomes/git_test.go
@@ -31,7 +31,7 @@ func TestImportFromRepo(t *testing.T) {
 	// Create a dummy file and commit it
 	err = os.MkdirAll(filepath.Join(tmpDir, "example"), 0755)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(tmpDir, "example", "metadata.yml"), []byte("name: example\ndescription: An example tome!\nauthor: test\ntactic: DEFENSE_EVASION\nparamdefs:\n  - name: msg\n    label: Message\n    type: string\n    placeholder: Something to print\n"), 0644)
+	err = os.WriteFile(filepath.Join(tmpDir, "example", "metadata.yml"), []byte("name: example\ndescription: An example tome!\nauthor: test\ntactic: DEFENSE_EVASION\nrun_on_schedule: '* * * * *'\nparamdefs:\n  - name: msg\n    label: Message\n    type: string\n    placeholder: Something to print\n"), 0644)
 	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(tmpDir, "example", "main.eldritch"), []byte("print(input_params['msg'])"), 0644)
 	require.NoError(t, err)
@@ -85,6 +85,7 @@ func TestImportFromRepo(t *testing.T) {
 	require.NotNil(t, testTome)
 	assert.Equal(t, "print(input_params['msg'])", strings.TrimSpace(testTome.Eldritch))
 	assert.Equal(t, `An example tome!`, testTome.Description)
+	assert.Equal(t, `* * * * *`, testTome.RunOnSchedule)
 	assert.Equal(t, `[{"name":"msg","label":"Message","type":"string","placeholder":"Something to print"}]`, testTome.ParamDefs)
 	testTomeAssets, err := testTome.QueryAssets().All(ctx)
 	assert.NoError(t, err)

--- a/tavern/tomes/parse.go
+++ b/tavern/tomes/parse.go
@@ -41,12 +41,13 @@ func (paramDef ParamDefinition) Validate() error {
 
 // MetadataDefinition defines the contents that should be present in all tome metadata.yml files
 type MetadataDefinition struct {
-	Name         string `yaml:"name"`
-	Description  string `yaml:"description"`
-	Author       string `yaml:"author"`
-	SupportModel string `yaml:"support_model"`
-	Tactic       string `yaml:"tactic"`
-	ParamDefs    []ParamDefinition
+	Name          string `yaml:"name"`
+	Description   string `yaml:"description"`
+	Author        string `yaml:"author"`
+	SupportModel  string `yaml:"support_model"`
+	Tactic        string `yaml:"tactic"`
+	RunOnSchedule string `yaml:"run_on_schedule"`
+	ParamDefs     []ParamDefinition
 }
 
 // Validate ensures the Tome metadata has been properly configured.
@@ -166,6 +167,7 @@ func UploadTomes(ctx context.Context, graph *ent.Client, fileSystem fs.ReadDirFS
 			SetParamDefs(string(paramdefs)).
 			SetSupportModel(tome.SupportModel(metadata.SupportModel)).
 			SetTactic(tome.Tactic(metadata.Tactic)).
+			SetRunOnSchedule(metadata.RunOnSchedule).
 			SetEldritch(eldritch).
 			AddAssets(tomeAssets...).
 			Save(ctx); err != nil {


### PR DESCRIPTION
Update our tome parsing to allow creating tomes with `run_on_schedule` if it is set in their `metadata.yml`.

---
*PR created automatically by Jules for task [9044207903023826577](https://jules.google.com/task/9044207903023826577) started by @KCarretto*