### PR TITLE
Fix capitalization of 'loading beacon info' in CreateQuest

### DIFF
--- a/tavern/internal/www/src/pages/create-quest/CreateQuest.tsx
+++ b/tavern/internal/www/src/pages/create-quest/CreateQuest.tsx
@@ -21,7 +21,7 @@ export const CreateQuest = () => {
             {error ? (
                 <EmptyState type={EmptyStateType.error} label="Error loading beacon info" />
             ) : isDataLoading ? (
-                <EmptyState type={EmptyStateType.loading} label="loading beacon info..." />
+                <EmptyState type={EmptyStateType.loading} label="Loading beacon info..." />
             ) : hasBeacons ? (
                 <QuestForm />
             ) : (


### PR DESCRIPTION
Fix capitalization of "loading beacon info" to "Loading beacon info..." in the CreateQuest component.

Changes:
* `tavern/internal/www/src/pages/create-quest/CreateQuest.tsx`: Capitalized the string "loading beacon info..."

---
*PR created automatically by Jules for task [10972508474203074979](https://jules.google.com/task/10972508474203074979) started by @KCarretto*