### PR TITLE
feat: Add Write Registry Tome

### DIFF
--- a/tavern/tomes/write_registry/main.eldritch
+++ b/tavern/tomes/write_registry/main.eldritch
@@ -1,0 +1,21 @@
+def write_registry(hive, path, key_name, key_type, key_value):
+    if sys.is_linux():
+        eprint("windows registry is unsupported on linux")
+        return
+
+    if key_type == "REG_DWORD" or key_type == "REG_QWORD":
+        val = int(key_value)
+        res = sys.write_reg_int(hive, path, key_name, key_type, val)
+    elif key_type == "REG_BINARY":
+        res = sys.write_reg_hex(hive, path, key_name, key_type, key_value)
+    else:
+        res = sys.write_reg_str(hive, path, key_name, key_type, key_value)
+
+    if res:
+        print(f"Successfully wrote {key_value} to {hive}\\{path}\\{key_name}")
+    else:
+        eprint(f"Failed to write to {hive}\\{path}\\{key_name}")
+
+
+write_registry(input_params['hive'], input_params['path'], input_params['key_name'], input_params['key_type'], input_params['key_value'])
+print()

--- a/tavern/tomes/write_registry/metadata.yml
+++ b/tavern/tomes/write_registry/metadata.yml
@@ -1,0 +1,26 @@
+name: Write Registry
+description: Set a registry subkey value at a provided hive and path.
+author: jules
+support_model: FIRST_PARTY
+tactic: IMPACT
+paramdefs:
+- name: hive
+  type: string
+  label: Registry hive
+  placeholder: "HKEY_LOCAL_MACHINE"
+- name: path
+  type: string
+  label: Registry key path
+  placeholder: "SOFTWARE\\Microsoft\\Windows\\CurrentVersion" # Single backslash can be used too but you may encounter issues if you specify "\x64" as that's hex.
+- name: key_name
+  type: string
+  label: Registry key name
+  placeholder: "MyKey"
+- name: key_type
+  type: string
+  label: Registry key type (e.g. REG_SZ, REG_DWORD)
+  placeholder: "REG_SZ"
+- name: key_value
+  type: string
+  label: Registry key value
+  placeholder: "MyValue"


### PR DESCRIPTION
Added a "Write Registry" tome to set a Windows registry key.

- Creates `write_registry` directory in `tavern/tomes`.
- Adds `metadata.yml` with parameters `hive`, `path`, `key_name`, `key_type`, and `key_value`.
- Adds `main.eldritch` containing the script logic.
- Adds an OS check to error on Linux.
- Supports `REG_DWORD`, `REG_QWORD`, `REG_BINARY`, and string types.

---
*PR created automatically by Jules for task [3332571259740485138](https://jules.google.com/task/3332571259740485138) started by @KCarretto*