### PR TITLE
Update Cloud SQL max_allowed_packet flag

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -244,10 +244,10 @@ resource "google_sql_database_instance" "tavern-sql-instance" {
   settings {
     tier = var.mysql_tier
 
-    # database_flags {
-    #   name  = "default_authentication_plugin"
-    #   value = "caching_sha2_password"
-    # }
+    database_flags {
+      name  = "max_allowed_packet"
+      value = "1073741824"
+    }
   }
 
   depends_on = [


### PR DESCRIPTION
The Cloud SQL instance provisioned by terraform now configures the `max_allowed_packet` flag, increasing it to 1Gb.

---
*PR created automatically by Jules for task [974306357314529294](https://jules.google.com/task/974306357314529294) started by @KCarretto*