### PR TITLE
Auto-save credentials to cache on successful auth

### DIFF
--- a/tavern/cli/auth/auth.go
+++ b/tavern/cli/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -154,6 +155,15 @@ func Authenticate(ctx context.Context, browser Browser, tavernURL string, opts .
 	case err := <-errCh:
 		return Token(""), fmt.Errorf("failed to obtain credentials: %w", err)
 	case token := <-tokenCh:
+		if options.CachePath != "" {
+			if err := os.MkdirAll(filepath.Dir(options.CachePath), 0700); err != nil {
+				slog.WarnContext(ctx, "failed to create credential cache directory", "path", options.CachePath, "error", err)
+			} else if err := os.WriteFile(options.CachePath, []byte(token), 0600); err != nil {
+				slog.WarnContext(ctx, "failed to write credential cache", "path", options.CachePath, "error", err)
+			} else {
+				slog.Debug("Saved authentication credentials to cache", "path", options.CachePath)
+			}
+		}
 		return token, nil
 	}
 }

--- a/tavern/cli/auth/auth_test.go
+++ b/tavern/cli/auth/auth_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -153,12 +155,22 @@ func TestAuthenticate(t *testing.T) {
 				return err
 			})
 
+			// Setup Cache
+			cachePath := filepath.Join(t.TempDir(), "test_cache")
+
 			// Authenticate
-			token, err := auth.Authenticate(ctx, browser, tc.tavernURL)
+			token, err := auth.Authenticate(ctx, browser, tc.tavernURL, auth.WithCacheFile(cachePath))
 
 			// Assertions
 			assert.Equal(t, tc.wantAccessToken, string(token))
 			assert.ErrorIs(t, err, tc.wantError)
+
+			// Assert Cache Written
+			if err == nil {
+				cacheContent, cacheErr := os.ReadFile(cachePath)
+				assert.NoError(t, cacheErr)
+				assert.Equal(t, tc.wantAccessToken, string(cacheContent))
+			}
 		})
 	}
 }

--- a/tavern/cli/auth/options.go
+++ b/tavern/cli/auth/options.go
@@ -1,7 +1,5 @@
 package auth
 
-
-
 type AuthOptions struct {
 	EnvAPIKeyName string
 	CachePath     string


### PR DESCRIPTION
Updates the `tavern` CLI auth package to automatically write a retrieved API key to the configured cache file if authentication was successful, creating the directory if necessary. Tests have been expanded to verify this behavior.

---
*PR created automatically by Jules for task [4494069843278243605](https://jules.google.com/task/4494069843278243605) started by @KCarretto*