### PR TITLE
Fix "invalid user_code" error when revoking device auth

### DIFF
--- a/tavern/internal/http/device_auth_test.go
+++ b/tavern/internal/http/device_auth_test.go
@@ -1,0 +1,167 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"realm.pub/tavern/internal/auth"
+	"realm.pub/tavern/internal/ent/deviceauth"
+	"realm.pub/tavern/internal/ent/enttest"
+	tavernhttp "realm.pub/tavern/internal/http"
+)
+
+func TestRDARevokeHandler(t *testing.T) {
+	ctx := context.Background()
+	var (
+		driverName     = "sqlite3"
+		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
+	)
+	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+	defer graph.Close()
+
+	// Set up users
+	adminUser := graph.User.Create().
+		SetName("admin").
+		SetOauthID("admin").
+		SetPhotoURL("http://google.com/").
+		SetIsActivated(true).
+		SetIsAdmin(true).
+		SaveX(ctx)
+
+	normalUser := graph.User.Create().
+		SetName("user").
+		SetOauthID("user").
+		SetPhotoURL("http://google.com/").
+		SetIsActivated(true).
+		SetIsAdmin(false).
+		SaveX(ctx)
+
+	otherUser := graph.User.Create().
+		SetName("other").
+		SetOauthID("other").
+		SetPhotoURL("http://google.com/").
+		SetIsActivated(true).
+		SetIsAdmin(false).
+		SaveX(ctx)
+
+	// Set up device auths
+	daAdmin := graph.DeviceAuth.Create().
+		SetUserCode("code_admin").
+		SetDeviceCode("device_admin").
+		SetStatus(deviceauth.StatusAPPROVED).
+		SetExpiresAt(time.Now().Add(1 * time.Hour)).
+		SetUser(adminUser).
+		SaveX(ctx)
+
+	daNormal := graph.DeviceAuth.Create().
+		SetUserCode("code_normal").
+		SetDeviceCode("device_normal").
+		SetStatus(deviceauth.StatusAPPROVED).
+		SetExpiresAt(time.Now().Add(1 * time.Hour)).
+		SetUser(normalUser).
+		SaveX(ctx)
+
+	daOther := graph.DeviceAuth.Create().
+		SetUserCode("code_other").
+		SetDeviceCode("device_other").
+		SetStatus(deviceauth.StatusAPPROVED).
+		SetExpiresAt(time.Now().Add(1 * time.Hour)).
+		SetUser(otherUser).
+		SaveX(ctx)
+
+	handler := tavernhttp.NewRDARevokeHandler(graph)
+
+	tests := []struct {
+		name       string
+		method     string
+		body       map[string]interface{}
+		userToken  string
+		wantStatus int
+	}{
+		{
+			name:       "Wrong method",
+			method:     http.MethodGet,
+			body:       nil,
+			userToken:  "",
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "Invalid body",
+			method:     http.MethodPost,
+			body:       nil,
+			userToken:  "",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Unauthenticated",
+			method:     http.MethodPost,
+			body:       map[string]interface{}{"user_code": daNormal.UserCode},
+			userToken:  "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "Invalid user code",
+			method:     http.MethodPost,
+			body:       map[string]interface{}{"user_code": "invalid"},
+			userToken:  normalUser.SessionToken,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "Revoke own device",
+			method:     http.MethodPost,
+			body:       map[string]interface{}{"user_code": daNormal.UserCode},
+			userToken:  normalUser.SessionToken,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Revoke other user device (non-admin)",
+			method:     http.MethodPost,
+			body:       map[string]interface{}{"user_code": daOther.UserCode},
+			userToken:  normalUser.SessionToken,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "Revoke other user device (admin)",
+			method:     http.MethodPost,
+			body:       map[string]interface{}{"user_code": daOther.UserCode},
+			userToken:  adminUser.SessionToken,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Revoke own device (admin)",
+			method:     http.MethodPost,
+			body:       map[string]interface{}{"user_code": daAdmin.UserCode},
+			userToken:  adminUser.SessionToken,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bodyBytes []byte
+			if tt.body != nil {
+				bodyBytes, _ = json.Marshal(tt.body)
+			} else if tt.method == http.MethodPost {
+				bodyBytes = []byte("invalid json")
+			}
+			req := httptest.NewRequest(tt.method, "/auth/rda/revoke", bytes.NewBuffer(bodyBytes))
+
+			if tt.userToken != "" {
+				authCtx, _ := auth.ContextFromSessionToken(req.Context(), graph, tt.userToken)
+				req = req.WithContext(authCtx)
+			}
+
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}

--- a/tavern/internal/www/src/pages/profile/DeviceAuth.tsx
+++ b/tavern/internal/www/src/pages/profile/DeviceAuth.tsx
@@ -79,7 +79,7 @@ const DeviceAuth: React.FC<DeviceAuthProps> = ({ devices, refetch }) => {
                 if (node.status === 'PENDING' || node.status === 'APPROVED') {
                     return (
                         <div className="flex justify-end">
-                            <Button buttonVariant="outline" buttonStyle={{ color: 'red', size: 'xs' }} onClick={() => handleRevokeDevice(node.id)}>
+                            <Button buttonVariant="outline" buttonStyle={{ color: 'red', size: 'xs' }} onClick={() => handleRevokeDevice(node.userCode)}>
                                 <Trash2 size={16} />
                             </Button>
                         </div>


### PR DESCRIPTION
Fixes a bug where revoking a device authorization via the UI results in an "invalid user_code" error.

**Changes:**
- Updated `tavern/internal/www/src/pages/profile/DeviceAuth.tsx` to pass `node.userCode` instead of `node.id` to the `handleRevokeDevice` function.
- Created `tavern/internal/http/device_auth_test.go` and added a test suite for `NewRDARevokeHandler` to ensure the revoke API endpoint functions correctly and handles both admin and normal user authorization constraints.

---
*PR created automatically by Jules for task [10053009158567028608](https://jules.google.com/task/10053009158567028608) started by @KCarretto*