### PR TITLE
Fix socks5_bin authentication to prioritize TAVERN_API_TOKEN

### DIFF
--- a/bin/socks5/auth.go
+++ b/bin/socks5/auth.go
@@ -11,7 +11,7 @@ import (
 )
 
 // EnvAPIKey is the name of the environment variable to optionally provide an API key
-const EnvAPIKey = "TAVERN_API_KEY"
+const EnvAPIKey = "TAVERN_API_TOKEN"
 
 func getAuthToken(ctx context.Context, tavernURL, cachePath string) (auth.Token, error) {
 	return auth.Authenticate(


### PR DESCRIPTION
Fix socks5_bin authentication to prioritize TAVERN_API_TOKEN over RDA. This addresses the failing E2E test.

---
*PR created automatically by Jules for task [6168827854427937255](https://jules.google.com/task/6168827854427937255) started by @hulto*