### PR TITLE
Update Zig version to latest master build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:trixie
 
-ARG ZIG_VERSION=0.16.0-dev.2877+627f03af9
+ARG ZIG_VERSION=0.16.0-dev.2905+5d71e3051
 
 ENV GOPATH=/go
 ENV RUSTUP_HOME=/usr/local/rustup \


### PR DESCRIPTION
The Zig version used in the devcontainer (and consequently in CI builds that use this Dockerfile) was outdated. This PR updates `ZIG_VERSION` in `.devcontainer/Dockerfile` to `0.16.0-dev.2905+5d71e3051`, which is the latest master build as of today. This ensures that `cargo-zigbuild` and other tools relying on Zig have the most recent toolchain.

---
*PR created automatically by Jules for task [720058169787344440](https://jules.google.com/task/720058169787344440) started by @hulto*