### PR TITLE
fix: bypass proxy for local server pubkey fetch in build script

### DIFF
--- a/implants/lib/pb/build.rs
+++ b/implants/lib/pb/build.rs
@@ -205,10 +205,11 @@ fn get_pub_key(yaml_config: Option<YamlConfigResult>) {
     let status_url = format!("{}/status", base_uri);
 
     // Make a GET request to /status
-    let response = match reqwest::blocking::get(&status_url) {
+    let client = reqwest::blocking::Client::builder().no_proxy().build().unwrap();
+    let response = match client.get(&status_url).send() {
         Ok(resp) => resp,
         Err(e) => {
-            println!("cargo:warning=Failed to connect to {}: {}", status_url, e);
+            println!("cargo:warning=Failed to connect to {}: {:?}", status_url, e);
             return;
         }
     };


### PR DESCRIPTION
Fixes an issue where `cargo build` in `implants/lib/pb` fails to fetch the public key from the local Tavern server due to proxy misconfigurations in development environments.

Changes made:
- Used `reqwest::blocking::Client::builder().no_proxy().build().unwrap().get(&status_url).send()` instead of `reqwest::blocking::get(&status_url)`.
- Replaced Display (`{}`) format for the error log with Debug (`{:?}`) to get more verbose error traces.

---
*PR created automatically by Jules for task [11601507693399375597](https://jules.google.com/task/11601507693399375597) started by @hulto*