### PR TITLE
Add pnet Connection implementing net.Conn over portals

### DIFF
--- a/tavern/internal/portals/pnet/connection.go
+++ b/tavern/internal/portals/pnet/connection.go
@@ -1,0 +1,160 @@
+package pnet
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+
+	"realm.pub/tavern/portals/portalpb"
+	"realm.pub/tavern/portals/stream"
+)
+
+// Connection implements net.Conn over portal motes.
+type Connection struct {
+	network string
+	dstAddr string
+	dstPort uint32
+
+	reader *stream.OrderedReader
+	writer *stream.OrderedWriter
+
+	readBuf []byte
+}
+
+// Dial creates a new portal network connection.
+func Dial(network, address, streamID string, sender stream.SenderFunc, receiver stream.ReceiverFunc) (net.Conn, error) {
+	if network != "tcp" && network != "udp" {
+		return nil, fmt.Errorf("unsupported network %q", network)
+	}
+
+	host, portStr, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+
+	port, err := strconv.ParseUint(portStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port: %w", err)
+	}
+
+	return &Connection{
+		network: network,
+		dstAddr: host,
+		dstPort: uint32(port),
+		reader:  stream.NewOrderedReader(receiver),
+		writer:  stream.NewOrderedWriter(streamID, sender),
+	}, nil
+}
+
+// Read reads data from the connection.
+func (c *Connection) Read(b []byte) (n int, err error) {
+	if len(c.readBuf) > 0 {
+		n = copy(b, c.readBuf)
+		c.readBuf = c.readBuf[n:]
+		return n, nil
+	}
+
+	for {
+		mote, err := c.reader.Read()
+		if err != nil {
+			return 0, err
+		}
+
+		var payloadData []byte
+		switch p := mote.Payload.(type) {
+		case *portalpb.Mote_Bytes:
+			if p.Bytes.Kind == portalpb.BytesPayloadKind_BYTES_PAYLOAD_KIND_CLOSE {
+				return 0, io.EOF
+			}
+			payloadData = p.Bytes.Data
+		case *portalpb.Mote_Tcp:
+			payloadData = p.Tcp.Data
+		case *portalpb.Mote_Udp:
+			payloadData = p.Udp.Data
+		default:
+			// ignore other payloads
+			continue
+		}
+
+		if len(payloadData) == 0 {
+			continue // keep waiting for actual data
+		}
+
+		n = copy(b, payloadData)
+		if n < len(payloadData) {
+			c.readBuf = payloadData[n:]
+		}
+		return n, nil
+	}
+}
+
+// Write writes data to the connection.
+func (c *Connection) Write(b []byte) (n int, err error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	if c.network == "tcp" {
+		err = c.writer.WriteTCP(b, c.dstAddr, c.dstPort)
+	} else if c.network == "udp" {
+		err = c.writer.WriteUDP(b, c.dstAddr, c.dstPort)
+	} else {
+		return 0, fmt.Errorf("unsupported network %q", c.network)
+	}
+
+	if err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// Close closes the connection.
+func (c *Connection) Close() error {
+	// Signal close
+	err := c.writer.WriteBytes(nil, portalpb.BytesPayloadKind_BYTES_PAYLOAD_KIND_CLOSE)
+	c.reader.Close()
+	return err
+}
+
+// LocalAddr returns the local network address.
+func (c *Connection) LocalAddr() net.Addr {
+	return &dummyAddr{network: c.network, address: "localhost:0"}
+}
+
+// RemoteAddr returns the remote network address.
+func (c *Connection) RemoteAddr() net.Addr {
+	return &dummyAddr{
+		network: c.network,
+		address: net.JoinHostPort(c.dstAddr, strconv.Itoa(int(c.dstPort))),
+	}
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection.
+func (c *Connection) SetDeadline(t time.Time) error {
+	if err := c.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return c.SetWriteDeadline(t)
+}
+
+// SetReadDeadline sets the deadline for future Read calls.
+func (c *Connection) SetReadDeadline(t time.Time) error {
+	c.reader.SetReadDeadline(t)
+	return nil
+}
+
+// SetWriteDeadline sets the deadline for future Write calls.
+func (c *Connection) SetWriteDeadline(t time.Time) error {
+	c.writer.SetWriteDeadline(t)
+	return nil
+}
+
+type dummyAddr struct {
+	network string
+	address string
+}
+
+func (a *dummyAddr) Network() string { return a.network }
+func (a *dummyAddr) String() string  { return a.address }

--- a/tavern/internal/portals/pnet/connection_test.go
+++ b/tavern/internal/portals/pnet/connection_test.go
@@ -1,0 +1,156 @@
+package pnet
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"realm.pub/tavern/portals/portalpb"
+)
+
+func TestConnection_ReadWriteTCP(t *testing.T) {
+	moteCh := make(chan *portalpb.Mote, 10)
+
+	sender := func(m *portalpb.Mote) error {
+		moteCh <- m
+		return nil
+	}
+
+	receiver := func() (*portalpb.Mote, error) {
+		m, ok := <-moteCh
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+
+	conn, err := Dial("tcp", "192.168.1.1:80", "test-stream", sender, receiver)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	assert.Equal(t, "tcp", conn.LocalAddr().Network())
+	assert.Equal(t, "localhost:0", conn.LocalAddr().String())
+	assert.Equal(t, "tcp", conn.RemoteAddr().Network())
+	assert.Equal(t, "192.168.1.1:80", conn.RemoteAddr().String())
+
+	// Test Write
+	n, err := conn.Write([]byte("hello world"))
+	require.NoError(t, err)
+	assert.Equal(t, 11, n)
+
+	// Test Read
+	buf := make([]byte, 5)
+	n, err = conn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", string(buf[:n]))
+
+	// Test Read remaining
+	buf2 := make([]byte, 10)
+	n, err = conn.Read(buf2)
+	require.NoError(t, err)
+	assert.Equal(t, 6, n)
+	assert.Equal(t, " world", string(buf2[:n]))
+}
+
+func TestConnection_ReadWriteUDP(t *testing.T) {
+	moteCh := make(chan *portalpb.Mote, 10)
+
+	sender := func(m *portalpb.Mote) error {
+		moteCh <- m
+		return nil
+	}
+
+	receiver := func() (*portalpb.Mote, error) {
+		m, ok := <-moteCh
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+
+	conn, err := Dial("udp", "10.0.0.1:53", "test-stream", sender, receiver)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Test Write
+	n, err := conn.Write([]byte("dns query"))
+	require.NoError(t, err)
+	assert.Equal(t, 9, n)
+
+	// Test Read
+	buf := make([]byte, 64)
+	n, err = conn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 9, n)
+	assert.Equal(t, "dns query", string(buf[:n]))
+}
+
+func TestConnection_CloseSignalsEOF(t *testing.T) {
+	moteCh := make(chan *portalpb.Mote, 10)
+
+	sender := func(m *portalpb.Mote) error {
+		moteCh <- m
+		return nil
+	}
+
+	receiver := func() (*portalpb.Mote, error) {
+		m, ok := <-moteCh
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+
+	conn, err := Dial("tcp", "1.1.1.1:443", "test-stream", sender, receiver)
+	require.NoError(t, err)
+
+	// simulate a remote close
+	conn.(*Connection).writer.WriteBytes(nil, portalpb.BytesPayloadKind_BYTES_PAYLOAD_KIND_CLOSE)
+
+	// Reading should hit the close mote
+	buf := make([]byte, 64)
+	_, err = conn.Read(buf)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestConnection_Deadlines(t *testing.T) {
+	moteCh := make(chan *portalpb.Mote, 10)
+
+	sender := func(m *portalpb.Mote) error {
+		time.Sleep(10 * time.Millisecond) // slight delay
+		moteCh <- m
+		return nil
+	}
+
+	receiver := func() (*portalpb.Mote, error) {
+		m := <-moteCh
+		return m, nil
+	}
+
+	conn, err := Dial("tcp", "1.1.1.1:443", "test-stream", sender, receiver)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Set an immediate read deadline
+	err = conn.SetReadDeadline(time.Now().Add(-1 * time.Second))
+	require.NoError(t, err)
+
+	buf := make([]byte, 64)
+	_, err = conn.Read(buf)
+	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+	// Reset deadline
+	err = conn.SetReadDeadline(time.Time{})
+	require.NoError(t, err)
+
+	// Set an immediate write deadline
+	err = conn.SetWriteDeadline(time.Now().Add(-1 * time.Second))
+	require.NoError(t, err)
+
+	_, err = conn.Write([]byte("too late"))
+	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
+}

--- a/tavern/portals/stream/reader.go
+++ b/tavern/portals/stream/reader.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"realm.pub/tavern/portals/portalpb"
@@ -20,6 +21,11 @@ type OrderedReader struct {
 	staleTimeout    time.Duration
 	firstBufferedAt time.Time
 	receiver        ReceiverFunc
+
+	moteCh       chan *portalpb.Mote
+	errCh        chan error
+	stopCh       chan struct{}
+	readDeadline time.Time
 }
 
 // WithMaxBufferedMessages sets the maximum number of out-of-order messages to buffer.
@@ -46,11 +52,49 @@ func NewOrderedReader(receiver ReceiverFunc, options ...func(*OrderedReader)) *O
 		maxBuffer:    1024,
 		staleTimeout: 5 * time.Second,
 		receiver:     receiver,
+		moteCh:       make(chan *portalpb.Mote),
+		errCh:        make(chan error, 1),
+		stopCh:       make(chan struct{}),
 	}
 	for _, opt := range options {
 		opt(reader)
 	}
+
+	go func() {
+		for {
+			m, err := receiver()
+			if err != nil {
+				select {
+				case reader.errCh <- err:
+				case <-reader.stopCh:
+				}
+				return
+			}
+			select {
+			case reader.moteCh <- m:
+			case <-reader.stopCh:
+				return
+			}
+		}
+	}()
+
 	return reader
+}
+
+// Close gracefully stops the background receiver goroutine.
+func (r *OrderedReader) Close() error {
+	select {
+	case <-r.stopCh:
+	default:
+		close(r.stopCh)
+	}
+	return nil
+}
+
+// SetReadDeadline sets the deadline for future Read calls.
+// A zero value for t means Read will not time out.
+func (r *OrderedReader) SetReadDeadline(t time.Time) {
+	r.readDeadline = t
 }
 
 // Read returns the next ordered Mote.
@@ -76,7 +120,34 @@ func (r *OrderedReader) Read() (*portalpb.Mote, error) {
 
 	// Read loop
 	for {
-		mote, err := r.receiver()
+		var mote *portalpb.Mote
+		var err error
+
+		if !r.readDeadline.IsZero() {
+			if time.Now().After(r.readDeadline) {
+				return nil, os.ErrDeadlineExceeded
+			}
+			timer := time.NewTimer(time.Until(r.readDeadline))
+			select {
+			case mote = <-r.moteCh:
+				timer.Stop()
+			case err = <-r.errCh:
+				timer.Stop()
+			case <-timer.C:
+				return nil, os.ErrDeadlineExceeded
+			case <-r.stopCh:
+				timer.Stop()
+				return nil, errors.New("reader closed")
+			}
+		} else {
+			select {
+			case mote = <-r.moteCh:
+			case err = <-r.errCh:
+			case <-r.stopCh:
+				return nil, errors.New("reader closed")
+			}
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/tavern/portals/stream/writer.go
+++ b/tavern/portals/stream/writer.go
@@ -1,6 +1,9 @@
 package stream
 
 import (
+	"os"
+	"time"
+
 	"realm.pub/tavern/portals/portalpb"
 )
 
@@ -10,8 +13,9 @@ type SenderFunc func(*portalpb.Mote) error
 
 // OrderedWriter uses a payloadSequencer to create motes that are then written to a destination.
 type OrderedWriter struct {
-	sequencer *payloadSequencer
-	sender    SenderFunc
+	sequencer     *payloadSequencer
+	sender        SenderFunc
+	writeDeadline time.Time
 }
 
 // NewOrderedWriter creates a new OrderedWriter.
@@ -22,20 +26,41 @@ func NewOrderedWriter(streamID string, sender SenderFunc) *OrderedWriter {
 	}
 }
 
+// SetWriteDeadline sets the deadline for future Write calls.
+func (w *OrderedWriter) SetWriteDeadline(t time.Time) {
+	w.writeDeadline = t
+}
+
+func (w *OrderedWriter) checkDeadline() error {
+	if !w.writeDeadline.IsZero() && time.Now().After(w.writeDeadline) {
+		return os.ErrDeadlineExceeded
+	}
+	return nil
+}
+
 // WriteBytes creates and writes a BytesMote.
 func (w *OrderedWriter) WriteBytes(data []byte, kind portalpb.BytesPayloadKind) error {
+	if err := w.checkDeadline(); err != nil {
+		return err
+	}
 	mote := w.sequencer.NewBytesMote(data, kind)
 	return w.sender(mote)
 }
 
 // WriteTCP creates and writes a TCPMote.
 func (w *OrderedWriter) WriteTCP(data []byte, dstAddr string, dstPort uint32) error {
+	if err := w.checkDeadline(); err != nil {
+		return err
+	}
 	mote := w.sequencer.NewTCPMote(data, dstAddr, dstPort)
 	return w.sender(mote)
 }
 
 // WriteUDP creates and writes a UDPMote.
 func (w *OrderedWriter) WriteUDP(data []byte, dstAddr string, dstPort uint32) error {
+	if err := w.checkDeadline(); err != nil {
+		return err
+	}
 	mote := w.sequencer.NewUDPMote(data, dstAddr, dstPort)
 	return w.sender(mote)
 }


### PR DESCRIPTION
Implements `net.Conn` over portals by using the stream packet infrastructure, which allows standard net operations like Dial, Read, Write, and Deadlines over Tavern's portal connections.

---
*PR created automatically by Jules for task [8883179146587030842](https://jules.google.com/task/8883179146587030842) started by @KCarretto*