### PR TITLE
feat: Add SSH over WebSocket portal handler

### DIFF
--- a/tavern/app.go
+++ b/tavern/app.go
@@ -41,6 +41,7 @@ import (
 	"realm.pub/tavern/internal/http/stream"
 	"realm.pub/tavern/internal/portals"
 	"realm.pub/tavern/internal/portals/mux"
+	"realm.pub/tavern/internal/portals/ssh"
 	"realm.pub/tavern/internal/redirectors"
 	"realm.pub/tavern/internal/secrets"
 	"realm.pub/tavern/internal/www"
@@ -409,6 +410,9 @@ func NewServer(ctx context.Context, options ...func(*Config)) (*Server, error) {
 		},
 		"/shell/ping": tavernhttp.Endpoint{
 			Handler: stream.NewPingHandler(client, wsShellMux),
+		},
+		"/portals/ssh/ws": tavernhttp.Endpoint{
+			Handler: ssh.NewHandler(client, portalMux),
 		},
 		"/": tavernhttp.Endpoint{
 			Handler:          www.NewHandler(httpLogger),

--- a/tavern/internal/portals/pnet/connection.go
+++ b/tavern/internal/portals/pnet/connection.go
@@ -96,10 +96,15 @@ func (c *Connection) Write(b []byte) (n int, err error) {
 		return 0, nil
 	}
 
+	// Copy the slice because Mux.Publish handles motes asynchronously and the caller
+	// may reuse the buffer 'b' immediately after Write returns.
+	dataCopy := make([]byte, len(b))
+	copy(dataCopy, b)
+
 	if c.network == "tcp" {
-		err = c.writer.WriteTCP(b, c.dstAddr, c.dstPort)
+		err = c.writer.WriteTCP(dataCopy, c.dstAddr, c.dstPort)
 	} else if c.network == "udp" {
-		err = c.writer.WriteUDP(b, c.dstAddr, c.dstPort)
+		err = c.writer.WriteUDP(dataCopy, c.dstAddr, c.dstPort)
 	} else {
 		return 0, fmt.Errorf("unsupported network %q", c.network)
 	}

--- a/tavern/internal/portals/ssh/websocket.go
+++ b/tavern/internal/portals/ssh/websocket.go
@@ -119,14 +119,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer recvCleanup()
 
 	receiver := func() (*portalpb.Mote, error) {
-		m, ok := <-recvCh
-		if !ok {
-			return nil, io.EOF
+		for {
+			m, ok := <-recvCh
+			if !ok {
+				return nil, io.EOF
+			}
+			// Only accept motes matching our streamID to avoid mixing sequence IDs
+			// from other TCP connections or shell streams on the same portal.
+			if m.StreamId != streamID {
+				continue
+			}
+			if m.GetBytes() != nil && m.GetBytes().Kind == portalpb.BytesPayloadKind_BYTES_PAYLOAD_KIND_CLOSE {
+				return nil, io.EOF
+			}
+			return m, nil
 		}
-		if m.GetBytes() != nil && m.GetBytes().Kind == portalpb.BytesPayloadKind_BYTES_PAYLOAD_KIND_CLOSE {
-			return nil, io.EOF
-		}
-		return m, nil
 	}
 
 	// Dial pnet

--- a/tavern/internal/portals/ssh/websocket.go
+++ b/tavern/internal/portals/ssh/websocket.go
@@ -1,0 +1,279 @@
+package ssh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/ssh"
+	"realm.pub/tavern/internal/ent"
+	"realm.pub/tavern/internal/ent/portal"
+	"realm.pub/tavern/internal/http/shell"
+	"realm.pub/tavern/internal/portals/mux"
+	"realm.pub/tavern/internal/portals/pnet"
+	"realm.pub/tavern/portals/portalpb"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+// Handler handles websocket connections that tunnel SSH sessions over portal network.
+type Handler struct {
+	graph *ent.Client
+	mux   *mux.Mux
+}
+
+// NewHandler creates a new SSH websocket handler.
+func NewHandler(graph *ent.Client, mux *mux.Mux) *Handler {
+	return &Handler{
+		graph: graph,
+		mux:   mux,
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Parse Query Parameters
+	portalIDStr := r.URL.Query().Get("portal_id")
+	target := r.URL.Query().Get("target")
+
+	if portalIDStr == "" || target == "" {
+		http.Error(w, "missing portal_id or target", http.StatusBadRequest)
+		return
+	}
+
+	portalID, err := strconv.Atoi(portalIDStr)
+	if err != nil {
+		http.Error(w, "invalid portal_id", http.StatusBadRequest)
+		return
+	}
+
+	// Parse target: user:password@host:port
+	// We'll use a crude parse since the format is strict for now.
+	var user, password, hostPort string
+	parts := strings.SplitN(target, "@", 2)
+	if len(parts) != 2 {
+		http.Error(w, "invalid target format, expected user:password@host:port", http.StatusBadRequest)
+		return
+	}
+	hostPort = parts[1]
+	userPass := strings.SplitN(parts[0], ":", 2)
+	user = userPass[0]
+	if len(userPass) == 2 {
+		password = userPass[1]
+	}
+
+	// Verify Portal
+	p, err := h.graph.Portal.Query().Where(portal.ID(portalID)).Only(ctx)
+	if err != nil {
+		http.Error(w, "portal not found", http.StatusNotFound)
+		return
+	}
+	if !p.ClosedAt.IsZero() {
+		http.Error(w, "portal is closed", http.StatusForbidden)
+		return
+	}
+
+	// Upgrade to websocket
+	wsConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to upgrade ssh websocket", "error", err)
+		return
+	}
+	defer wsConn.Close()
+
+	// Open Portal Mux
+	cleanupPortal, err := h.mux.OpenPortal(ctx, portalID)
+	if err != nil {
+		wsConn.WriteJSON(shell.WebsocketErrorMessage{
+			Kind:  shell.WebsocketMessageKindError,
+			Error: fmt.Sprintf("Failed to open portal: %v", err),
+		})
+		return
+	}
+	defer cleanupPortal()
+
+	topicIn := h.mux.TopicIn(portalID)
+	topicOut := h.mux.TopicOut(portalID)
+
+	// Stream ID
+	streamID := fmt.Sprintf("ssh-ws-%d", time.Now().UnixNano())
+
+	// pnet dial requirements
+	sender := func(m *portalpb.Mote) error {
+		return h.mux.Publish(context.Background(), topicIn, m)
+	}
+
+	recvCh, recvCleanup := h.mux.Subscribe(topicOut)
+	defer recvCleanup()
+
+	receiver := func() (*portalpb.Mote, error) {
+		m, ok := <-recvCh
+		if !ok {
+			return nil, io.EOF
+		}
+		if m.GetBytes() != nil && m.GetBytes().Kind == portalpb.BytesPayloadKind_BYTES_PAYLOAD_KIND_CLOSE {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+
+	// Dial pnet
+	conn, err := pnet.Dial("tcp", hostPort, streamID, sender, receiver)
+	if err != nil {
+		wsConn.WriteJSON(shell.WebsocketErrorMessage{
+			Kind:  shell.WebsocketMessageKindError,
+			Error: fmt.Sprintf("Failed to dial portal network: %v", err),
+		})
+		return
+	}
+	defer conn.Close()
+
+	// Setup SSH Client Config
+	sshConfig := &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.Password(password)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         15 * time.Second,
+	}
+
+	// Connect SSH over pnet connection
+	sshConnConn, chans, reqs, err := ssh.NewClientConn(conn, hostPort, sshConfig)
+	if err != nil {
+		wsConn.WriteJSON(shell.WebsocketErrorMessage{
+			Kind:  shell.WebsocketMessageKindError,
+			Error: fmt.Sprintf("Failed to establish SSH connection: %v", err),
+		})
+		return
+	}
+	sshClient := ssh.NewClient(sshConnConn, chans, reqs)
+	defer sshClient.Close()
+
+	session, err := sshClient.NewSession()
+	if err != nil {
+		wsConn.WriteJSON(shell.WebsocketErrorMessage{
+			Kind:  shell.WebsocketMessageKindError,
+			Error: fmt.Sprintf("Failed to open SSH session: %v", err),
+		})
+		return
+	}
+	defer session.Close()
+
+	// Request PTY
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}
+	if err := session.RequestPty("xterm", 80, 40, modes); err != nil {
+		wsConn.WriteJSON(shell.WebsocketErrorMessage{
+			Kind:  shell.WebsocketMessageKindError,
+			Error: fmt.Sprintf("Failed to request PTY: %v", err),
+		})
+		return
+	}
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		return
+	}
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		return
+	}
+
+	if err := session.Shell(); err != nil {
+		wsConn.WriteJSON(shell.WebsocketErrorMessage{
+			Kind:  shell.WebsocketMessageKindError,
+			Error: fmt.Sprintf("Failed to start shell: %v", err),
+		})
+		return
+	}
+
+	// Goroutines to proxy IO
+	errCh := make(chan error, 4)
+	outCh := make(chan interface{}, 32)
+
+	// Single writer goroutine for websocket to prevent concurrent write panics
+	go func() {
+		for msg := range outCh {
+			if err := wsConn.WriteJSON(msg); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	// WebSocket -> SSH Stdin
+	go func() {
+		for {
+			_, msg, err := wsConn.ReadMessage()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			var inputMsg shell.WebsocketTaskInputMessage
+			if err := json.Unmarshal(msg, &inputMsg); err == nil && inputMsg.Kind == shell.WebsocketMessageKindInput {
+				stdin.Write([]byte(inputMsg.Input))
+			}
+		}
+	}()
+
+	// SSH Stdout -> WebSocket
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := stdout.Read(buf)
+			if n > 0 {
+				outCh <- shell.WebsocketTaskOutputMessage{
+					Kind:   shell.WebsocketMessageKindOutput,
+					Output: string(buf[:n]),
+				}
+			}
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	// SSH Stderr -> WebSocket
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := stderr.Read(buf)
+			if n > 0 {
+				outCh <- shell.WebsocketTaskErrorMessage{
+					Kind:  shell.WebsocketMessageKindTaskError,
+					Error: string(buf[:n]),
+				}
+			}
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	// Wait for session to finish or an error to occur
+	go func() {
+		errCh <- session.Wait()
+	}()
+
+	<-errCh
+}

--- a/tavern/tests/e2e/utils/pssh/main.go
+++ b/tavern/tests/e2e/utils/pssh/main.go
@@ -57,9 +57,13 @@ func main() {
 	u.RawQuery = q.Encode()
 
 	// Connect
-	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		log.Fatalf("Failed to dial websocket: %v", err)
+		if resp != nil {
+			log.Fatalf("Failed to dial websocket: %v (Status: %s)", err, resp.Status)
+		} else {
+			log.Fatalf("Failed to dial websocket: %v", err)
+		}
 	}
 	defer c.Close()
 

--- a/tavern/tests/e2e/utils/pssh/main.go
+++ b/tavern/tests/e2e/utils/pssh/main.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/term"
+)
+
+type WebsocketMessageKind string
+
+const (
+	WebsocketMessageKindInput     = "INPUT"
+	WebsocketMessageKindOutput    = "OUTPUT"
+	WebsocketMessageKindTaskError = "TASK_ERROR"
+	WebsocketMessageKindError     = "ERROR"
+)
+
+type WebsocketTaskInputMessage struct {
+	Kind  WebsocketMessageKind `json:"kind"`
+	Input string               `json:"input"`
+}
+
+type WebsocketTaskOutputMessage struct {
+	Kind   WebsocketMessageKind `json:"kind"`
+	Output string               `json:"output"`
+}
+
+type WebsocketErrorMessage struct {
+	Kind  WebsocketMessageKind `json:"kind"`
+	Error string               `json:"error"`
+}
+
+func main() {
+	portalID := flag.String("portal", "", "Portal ID")
+	target := flag.String("target", "", "Target SSH Server (user:pass@host:port)")
+	wsURL := flag.String("url", "ws://localhost/portals/ssh/ws", "WebSocket Endpoint URL")
+	flag.Parse()
+
+	if *portalID == "" || *target == "" {
+		log.Fatalf("Usage: pssh -portal <portal_id> -target <target> [-url <websocket_url>]")
+	}
+
+	u, err := url.Parse(*wsURL)
+	if err != nil {
+		log.Fatalf("Invalid websocket URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("portal_id", *portalID)
+	q.Set("target", *target)
+	u.RawQuery = q.Encode()
+
+	// Connect
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		log.Fatalf("Failed to dial websocket: %v", err)
+	}
+	defer c.Close()
+
+	// Setup Terminal in Raw Mode
+	fd := int(os.Stdin.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		log.Fatalf("Failed to set raw mode: %v", err)
+	}
+	defer term.Restore(fd, oldState)
+
+	// Receiver loop
+	go func() {
+		for {
+			_, message, err := c.ReadMessage()
+			if err != nil {
+				// We don't log cleanly because we are in raw mode, but a print is fine
+				fmt.Printf("\r\n[!] Disconnected: %v\r\n", err)
+				term.Restore(fd, oldState)
+				os.Exit(0)
+				return
+			}
+
+			// We need to unmarshal to check what it is
+			// Because we can have OUTPUT or TASK_ERROR or ERROR
+			var generic map[string]interface{}
+			if err := json.Unmarshal(message, &generic); err == nil {
+				kind, _ := generic["kind"].(string)
+				switch kind {
+				case WebsocketMessageKindOutput, WebsocketMessageKindTaskError:
+					if out, ok := generic["output"].(string); ok {
+						fmt.Print(out)
+					}
+					if out, ok := generic["error"].(string); ok {
+						fmt.Print(out)
+					}
+				case WebsocketMessageKindError:
+					if out, ok := generic["error"].(string); ok {
+						fmt.Printf("\r\n[ERROR] %s\r\n", out)
+					}
+				}
+			}
+		}
+	}()
+
+	// Read from stdin byte-by-byte
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			fmt.Printf("\r\nError reading stdin: %v\r\n", err)
+			break
+		}
+
+		msg := WebsocketTaskInputMessage{
+			Kind:  WebsocketMessageKindInput,
+			Input: string(b),
+		}
+		data, err := json.Marshal(msg)
+		if err != nil {
+			continue
+		}
+
+		if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
+			fmt.Printf("\r\nError writing message: %v\r\n", err)
+			break
+		}
+	}
+}

--- a/test_sshecho.sh
+++ b/test_sshecho.sh
@@ -3,4 +3,7 @@ go run ./bin/e2e/sshecho &
 ECHO_PID=$!
 sleep 2
 
+python3 -c "import socket, time; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.connect(('127.0.0.1', 2222)); s.send(b'SSH-2.0-Go\r\n'); time.sleep(1); s.send(b'\x00\x00\x00\x00\x00\x00'); time.sleep(1);" &
+sleep 3
+
 kill $ECHO_PID

--- a/test_sshecho.sh
+++ b/test_sshecho.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+go run ./bin/e2e/sshecho &
+ECHO_PID=$!
+sleep 2
+
+kill $ECHO_PID


### PR DESCRIPTION
This PR adds an SSH websocket portal handler utilizing the `pnet` package to bridge websocket HTTP upgrade requests to an SSH session over portal infrastructure. It also includes a `pssh` test utility that operates as an interactive CLI SSH client over this WebSocket endpoint.

---
*PR created automatically by Jules for task [8453755058048500210](https://jules.google.com/task/8453755058048500210) started by @KCarretto*