### PR TITLE
feat: add ssh meta-command to browser repl

### DIFF
--- a/implants/lib/eldritch/eldritch-wasm/src/browser.rs
+++ b/implants/lib/eldritch/eldritch-wasm/src/browser.rs
@@ -11,6 +11,8 @@ use wasm_bindgen::prelude::*;
 pub enum MetaCommand {
     #[serde(rename = "help")]
     Help { target: Option<String> },
+    #[serde(rename = "ssh")]
+    Ssh { target: String },
 }
 
 #[cfg(feature = "fake_bindings")]
@@ -203,6 +205,18 @@ impl BrowserRepl {
                                             }
                                         } else {
                                             meta_command = Some(MetaCommand::Help { target: None });
+                                        }
+                                    } else if id == "ssh" {
+                                        if args.len() == 1 {
+                                            if let eldritch_core::Argument::Positional(arg_expr) =
+                                                &args[0]
+                                            {
+                                                if let ExprKind::Literal(eldritch_core::Value::String(target)) = &arg_expr.kind {
+                                                    meta_command = Some(MetaCommand::Ssh {
+                                                        target: target.clone(),
+                                                    });
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/implants/lib/eldritch/eldritch-wasm/src/browser_test.rs
+++ b/implants/lib/eldritch/eldritch-wasm/src/browser_test.rs
@@ -51,6 +51,16 @@ mod tests {
     }
 
     #[test]
+    fn test_browser_repl_meta_ssh() {
+        let mut repl = BrowserRepl::new();
+
+        let res = repl.input("ssh(\"test:pass@127.0.0.1:22\")");
+        assert!(res.contains("\"status\": \"meta\""));
+        assert!(res.contains("\"type\": \"ssh\""));
+        assert!(res.contains("\"target\": \"test:pass@127.0.0.1:22\""));
+    }
+
+    #[test]
     fn test_browser_repl_complete() {
         let repl = BrowserRepl::new();
 

--- a/tavern/internal/www/src/App.tsx
+++ b/tavern/internal/www/src/App.tsx
@@ -11,6 +11,7 @@ import HostDetails from "./pages/host-details/HostDetails";
 import { Dashboard } from "./pages/dashboard";
 import Shell from "./pages/shell/Shell";
 import ShellV2 from "./pages/shellv2";
+import SshTerminal from "./pages/ssh/SshTerminal";
 import { UserPreferencesContextProvider } from "./context/UserPreferences";
 import { AdminPortal } from "./pages/admin/AdminPortal";
 import Assets from "./pages/assets/Assets";
@@ -80,6 +81,10 @@ const router = createBrowserRouter([
   {
     path: "shellv2/:shellId",
     element: <ShellV2 />,
+  },
+  {
+    path: "ssh",
+    element: <SshTerminal />,
   },
 ]);
 

--- a/tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts
+++ b/tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts
@@ -59,7 +59,8 @@ export const useShellTerminal = (
     error: any,
     shellData: any,
     setPortalId: (id: number | null) => void,
-    isLateCheckin: boolean
+    isLateCheckin: boolean,
+    portalId: number | null
 ) => {
     const termRef = useRef<HTMLDivElement>(null);
     const termInstance = useRef<Terminal | null>(null);
@@ -889,6 +890,14 @@ export const useShellTerminal = (
                             } else {
                                 term.write(`No documentation found for: ${target}\r\n`);
                             }
+                        } else if (metaCmd?.type === "ssh") {
+                            const target = metaCmd.target;
+                            if (portalId) {
+                                window.open(`/ssh?portal_id=${portalId}&target=${encodeURIComponent(target)}`, '_blank');
+                                term.write(`Opening SSH connection to ${target} in a new tab...\r\n`);
+                            } else {
+                                term.write(`\r\n\x1b[31mError: Active portal not found. SSH requires an active portal.\x1b[0m\r\n`);
+                            }
                         }
                     }
                     term.write(">>> ");
@@ -1005,6 +1014,14 @@ export const useShellTerminal = (
                                     term.write(`${wrappedDesc}\r\n`);
                                 } else {
                                     term.write(`No documentation found for: ${target}\r\n`);
+                                }
+                            } else if (metaCmd?.type === "ssh") {
+                                const target = metaCmd.target;
+                                if (portalId) {
+                                    window.open(`/ssh?portal_id=${portalId}&target=${encodeURIComponent(target)}`, '_blank');
+                                    term.write(`Opening SSH connection to ${target} in a new tab...\r\n`);
+                                } else {
+                                    term.write(`\r\n\x1b[31mError: Active portal not found. SSH requires an active portal.\x1b[0m\r\n`);
                                 }
                             }
                         }

--- a/tavern/internal/www/src/pages/shellv2/index.tsx
+++ b/tavern/internal/www/src/pages/shellv2/index.tsx
@@ -38,7 +38,7 @@ const ShellV2 = () => {
         connectionMessage,
         handleTooltipMouseEnter,
         handleTooltipMouseLeave
-    } = useShellTerminal(shellId, loading, error, shellData, setPortalId, isLateCheckin);
+    } = useShellTerminal(shellId, loading, error, shellData, setPortalId, isLateCheckin, portalId);
 
     if (connectionError) {
         return (

--- a/tavern/internal/www/src/pages/ssh/SshTerminal.tsx
+++ b/tavern/internal/www/src/pages/ssh/SshTerminal.tsx
@@ -1,0 +1,114 @@
+import { Terminal } from "@xterm/xterm";
+import { AttachAddon } from 'xterm-addon-attach';
+import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from "react-router-dom";
+import { useToast } from "@chakra-ui/react";
+import '@xterm/xterm/css/xterm.css';
+import { EmptyState, EmptyStateType } from "../../components/tavern-base-ui/EmptyState";
+import Badge from "../../components/tavern-base-ui/badge/Badge";
+
+const SshTerminal = () => {
+    const [searchParams] = useSearchParams();
+    const portalId = searchParams.get('portal_id');
+    const target = searchParams.get('target');
+    const toast = useToast();
+
+    const [wsIsOpen, setWsIsOpen] = useState(false);
+    const ws = useRef<WebSocket | null>(null);
+    const termRef = useRef<Terminal | null>(null);
+
+    if (termRef.current === null) {
+        termRef.current = new Terminal();
+    }
+
+    // Setup SSH WebSocket
+    useEffect(() => {
+        if (!portalId || !target) {
+            toast({
+                title: 'Missing parameters',
+                description: 'Both portal_id and target are required',
+                status: 'error',
+                duration: null,
+                isClosable: true,
+            });
+            return;
+        }
+
+        if (!ws.current) {
+            const scheme = window.location.protocol === "https:" ? 'wss' : 'ws';
+            const socket = new WebSocket(`${scheme}://${window.location.host}/portals/ssh/ws?portal_id=${portalId}&target=${encodeURIComponent(target)}`);
+
+            socket.onopen = (e) => {
+                setWsIsOpen(true);
+                toast({
+                    title: 'SSH Connected',
+                    description: `Connected to ${target}`,
+                    status: 'success',
+                    duration: 6000,
+                    isClosable: true,
+                });
+                const attachAddon = new AttachAddon(socket);
+                termRef.current?.loadAddon(attachAddon);
+            };
+            socket.onerror = (e) => {
+                toast({
+                    title: 'SSH Connection Error',
+                    description: `Failed to connect to ${target}`,
+                    status: 'error',
+                    duration: 6000,
+                    isClosable: true,
+                })
+            }
+            socket.onclose = (e) => {
+                setWsIsOpen(false);
+                toast({
+                    title: 'SSH Closed',
+                    description: `Connection to ${target} closed`,
+                    status: 'info',
+                    duration: 6000,
+                    isClosable: true,
+                })
+            }
+
+            ws.current = socket;
+        }
+
+        // Cleanup
+        return () => {
+            if (ws.current) {
+                ws.current.close();
+                ws.current = null;
+            }
+        }
+    }, [portalId, target, toast]);
+
+    const renderTerminal = (div: HTMLDivElement) => { if (div) { termRef.current?.open(div); } };
+
+    if (!portalId || !target) {
+         return <EmptyState label="Missing parameters" type={EmptyStateType.error} />;
+    }
+
+    return (
+        <div className="flex flex-col h-screen p-5 bg-[#1e1e1e] text-[#d4d4d4]">
+            <div className="border-b-2 border-gray-600 pb-4 mb-4 sm:flex flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-2">
+                    <div className="flex flex-row gap-4 items-center">
+                        <h3 className="text-xl font-semibold leading-6 text-white">SSH Session</h3>
+                        <Badge badgeStyle={{ color: "purple" }} >{target}</Badge>
+                        <Badge badgeStyle={{ color: "gray" }} >Portal {portalId}</Badge>
+                    </div>
+                </div>
+            </div>
+
+            {
+                wsIsOpen ?
+                    <div id="terminal" className="w-full h-full flex-grow" ref={renderTerminal} /> :
+                    <div className="flex items-center justify-center h-full">
+                        <div className="text-xl text-gray-400">Connecting...</div>
+                    </div>
+            }
+        </div>
+    );
+}
+
+export default SshTerminal;


### PR DESCRIPTION
This pull request adds a new browser REPL `ssh` meta command (`ssh("user:password@target")`).

It enables browser REPLs to spawn standard terminal windows via xterm and websocket bindings directly into an active, tunneled SSH session.

*   Updated `implants/lib/eldritch/eldritch-wasm` logic to parse the command and proxy the meta event down to TS.
*   Added `SshTerminal.tsx` as an Xterm container for the new session, directly connecting to `/portals/ssh/ws`.
*   Updated TS Hooks and routing.

---
*PR created automatically by Jules for task [7239299451537543956](https://jules.google.com/task/7239299451537543956) started by @KCarretto*