### PR TITLE
feat(eldritch): refactor dns to list and add CNAME support

### DIFF
--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -633,10 +633,10 @@ The `dns` library enables DNS lookups within Eldritch scripts.
 
 ### dns.list
 
-`dns.list(domain: str, record_type: Option<str>, nameserver: Option<str>) -> List<str>`
+`dns.list(domain: str, kind: Option<str>, nameserver: Option<str>) -> List<str>`
 
 The **dns.list** method resolves the given domain name to the specified DNS record type.
-It supports querying IPv4 addresses ("A") and aliases ("CNAME"). If `record_type` is not provided, it defaults to "A".
+It supports querying IPv4 addresses ("A") and aliases ("CNAME"). If `kind` is not provided, it defaults to "A".
 An optional nameserver IP (e.g. "8.8.8.8") can be provided to query a specific DNS server instead of the system default.
 
 ```python
@@ -645,7 +645,7 @@ ips = dns.list("google.com")
 print(ips) # Output: ["142.251.41.14", ...]
 
 # Fetch a CNAME explicitly
-cnames = dns.list("www.google.com", record_type="CNAME")
+cnames = dns.list("www.google.com", kind="CNAME")
 print(cnames)
 
 # Custom nameserver

--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -631,20 +631,25 @@ The **crypto.sha256** method calculates the SHA256 hash of the provided data.
 
 The `dns` library enables DNS lookups within Eldritch scripts.
 
-### dns.list_a_records
+### dns.list
 
-`dns.list_a_records(domain: str, nameserver: Option<str>) -> List<str>`
+`dns.list(domain: str, record_type: Option<str>, nameserver: Option<str>) -> List<str>`
 
-The **dns.list_a_records** method resolves the given domain name to its IPv4 addresses (A records).
+The **dns.list** method resolves the given domain name to the specified DNS record type.
+It supports querying IPv4 addresses ("A") and aliases ("CNAME"). If `record_type` is not provided, it defaults to "A".
 An optional nameserver IP (e.g. "8.8.8.8") can be provided to query a specific DNS server instead of the system default.
 
 ```python
-# Default system nameserver
-ips = dns.list_a_records("google.com")
+# Default to "A" records using system nameserver
+ips = dns.list("google.com")
 print(ips) # Output: ["142.251.41.14", ...]
 
+# Fetch a CNAME explicitly
+cnames = dns.list("www.google.com", record_type="CNAME")
+print(cnames)
+
 # Custom nameserver
-cloudflare_ips = dns.list_a_records("google.com", nameserver="1.1.1.1")
+cloudflare_ips = dns.list("google.com", nameserver="1.1.1.1")
 print(cloudflare_ips)
 ```
 

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
@@ -14,7 +14,9 @@ impl DnsLibrary for DnsLibraryFake {
         record_type: Option<String>,
         _nameserver: Option<String>,
     ) -> Result<Vec<String>, String> {
-        let rtype = record_type.unwrap_or_else(|| alloc::string::String::from("A")).to_uppercase();
+        let rtype = record_type
+            .unwrap_or_else(|| alloc::string::String::from("A"))
+            .to_uppercase();
         match rtype.as_str() {
             "A" => Ok(alloc::vec!["127.0.0.1".into(), "10.0.0.1".into()]),
             "CNAME" => Ok(alloc::vec!["alias.example.com".into()]),

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
@@ -8,12 +8,17 @@ use eldritch_macros::eldritch_library_impl;
 pub struct DnsLibraryFake;
 
 impl DnsLibrary for DnsLibraryFake {
-    fn list_a_records(
+    fn list(
         &self,
         _domain: String,
+        record_type: Option<String>,
         _nameserver: Option<String>,
     ) -> Result<Vec<String>, String> {
-        // Return dummy IPs for testing
-        Ok(alloc::vec!["127.0.0.1".into(), "10.0.0.1".into()])
+        let rtype = record_type.unwrap_or_else(|| alloc::string::String::from("A")).to_uppercase();
+        match rtype.as_str() {
+            "A" => Ok(alloc::vec!["127.0.0.1".into(), "10.0.0.1".into()]),
+            "CNAME" => Ok(alloc::vec!["alias.example.com".into()]),
+            _ => Err(alloc::format!("Unsupported record type: {}", rtype)),
+        }
     }
 }

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
@@ -11,10 +11,10 @@ impl DnsLibrary for DnsLibraryFake {
     fn list(
         &self,
         _domain: String,
-        record_type: Option<String>,
+        kind: Option<String>,
         _nameserver: Option<String>,
     ) -> Result<Vec<String>, String> {
-        let rtype = record_type
+        let rtype = kind
             .unwrap_or_else(|| alloc::string::String::from("A"))
             .to_uppercase();
         match rtype.as_str() {

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/lib.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/lib.rs
@@ -15,20 +15,22 @@ pub mod std;
 /// The `dns` library enables the agent to make DNS queries.
 pub trait DnsLibrary {
     #[eldritch_method]
-    /// Resolves the A records for a domain.
+    /// Resolves DNS records for a domain.
     ///
     /// **Parameters**
     /// - `domain` (`str`): The domain name to resolve.
+    /// - `record_type` (`Option<str>`): An optional record type to query ("A" or "CNAME"). Defaults to "A".
     /// - `nameserver` (`Option<str>`): An optional nameserver IP to query (e.g. "8.8.8.8").
     ///
     /// **Returns**
-    /// - `List<str>`: A list of IPv4 addresses.
+    /// - `List<str>`: A list of result strings depending on the record type.
     ///
     /// **Errors**
-    /// - Returns an error string if resolution fails.
-    fn list_a_records(
+    /// - Returns an error string if resolution fails or the record type is unsupported.
+    fn list(
         &self,
         domain: String,
+        record_type: Option<String>,
         nameserver: Option<String>,
     ) -> Result<Vec<String>, String>;
 }

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/lib.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/lib.rs
@@ -19,7 +19,7 @@ pub trait DnsLibrary {
     ///
     /// **Parameters**
     /// - `domain` (`str`): The domain name to resolve.
-    /// - `record_type` (`Option<str>`): An optional record type to query ("A" or "CNAME"). Defaults to "A".
+    /// - `kind` (`Option<str>`): An optional record kind to query ("A" or "CNAME"). Defaults to "A".
     /// - `nameserver` (`Option<str>`): An optional nameserver IP to query (e.g. "8.8.8.8").
     ///
     /// **Returns**
@@ -30,7 +30,7 @@ pub trait DnsLibrary {
     fn list(
         &self,
         domain: String,
-        record_type: Option<String>,
+        kind: Option<String>,
         nameserver: Option<String>,
     ) -> Result<Vec<String>, String>;
 }

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/std/mod.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/std/mod.rs
@@ -10,9 +10,10 @@ use hickory_resolver::config::*;
 pub struct StdDnsLibrary;
 
 impl DnsLibrary for StdDnsLibrary {
-    fn list_a_records(
+    fn list(
         &self,
         domain: String,
+        record_type: Option<String>,
         nameserver: Option<String>,
     ) -> Result<Vec<String>, String> {
         let mut config = ResolverConfig::default();
@@ -32,13 +33,25 @@ impl DnsLibrary for StdDnsLibrary {
         let resolver = Resolver::new(config, ResolverOpts::default())
             .map_err(|e| format!("Failed to create resolver: {}", e))?;
 
-        // This is a blocking resolution. For an A record, we only want IPv4
-        let response = resolver
-            .ipv4_lookup(&domain)
-            .map_err(|e| format!("Failed to resolve {}: {}", domain, e))?;
-
-        let ips: Vec<String> = response.iter().map(|ip| ip.to_string()).collect();
-
-        Ok(ips)
+        let rtype = record_type.unwrap_or_else(|| alloc::string::String::from("A"));
+        match rtype.to_uppercase().as_str() {
+            "A" => resolve_a_records(&resolver, &domain),
+            "CNAME" => resolve_cname_records(&resolver, &domain),
+            _ => Err(format!("Unsupported record type: {}", rtype)),
+        }
     }
+}
+
+fn resolve_a_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .ipv4_lookup(domain)
+        .map_err(|e| format!("Failed to resolve A records for {}: {}", domain, e))?;
+    Ok(response.iter().map(|ip| ip.to_string()).collect())
+}
+
+fn resolve_cname_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .lookup(domain, hickory_resolver::proto::rr::RecordType::CNAME)
+        .map_err(|e| format!("Failed to resolve CNAME for {}: {}", domain, e))?;
+    Ok(response.iter().map(|ip| ip.to_string()).collect())
 }

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/std/mod.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/std/mod.rs
@@ -13,7 +13,7 @@ impl DnsLibrary for StdDnsLibrary {
     fn list(
         &self,
         domain: String,
-        record_type: Option<String>,
+        kind: Option<String>,
         nameserver: Option<String>,
     ) -> Result<Vec<String>, String> {
         let mut config = ResolverConfig::default();
@@ -33,7 +33,7 @@ impl DnsLibrary for StdDnsLibrary {
         let resolver = Resolver::new(config, ResolverOpts::default())
             .map_err(|e| format!("Failed to create resolver: {}", e))?;
 
-        let rtype = record_type.unwrap_or_else(|| alloc::string::String::from("A"));
+        let rtype = kind.unwrap_or_else(|| alloc::string::String::from("A"));
         match rtype.to_uppercase().as_str() {
             "A" => resolve_a_records(&resolver, &domain),
             "CNAME" => resolve_cname_records(&resolver, &domain),


### PR DESCRIPTION
# Refactor `dns` library and add CNAME support

### Overview
This PR refactors our newly introduced `dns.list_a_records` function to be more generic and extensible. The core method has been renamed to `dns.list` and now accepts an optional `record_type` parameter (capable of resolving `"A"` and `"CNAME"` records natively). To ensure code quality and testability, resolution logic within the `std` bindings has been separated into dedicated internal helper methods.

### Key Changes
* **API Redesign**: Replaced the rigid `dns.list_a_records` with `dns.list(domain, record_type='A', nameserver=None)`, enabling multi-type DNS probing.
* **CNAME Support**: Operators can now resolve `CNAME` records by invoking `dns.list("domain.com", record_type="CNAME")`. Defaults safely to IPv4 (`A`) if unspecified.
* **Architectural Flow**: Migrated the internal resolution logic from sweeping monolith functions into streamlined `resolve_a_records()` and `resolve_cname_records()` functions within `std/mod.rs` for readability and maintainability.
* **Testing / Mock Adjustments**: Extended `DnsLibraryFake` to appropriately handle assertions over both record types to guarantee mock-test coverage without breaking `cargo check`/WASM builds.
* **Documentation**: Overhauled `docs/_docs/user-guide/eldritch.md` to reflect `dns.list` along with functional snippet examples capturing the default and keyword invocation structures.

### Testing
- [x] Verified `cargo test -p eldritch` succeeds
- [x] Checked `cargo check -p eldritch-libdns`
- [x] Tested both `A` and `CNAME` return values in `fake`/`std` logic paths.
