### PR TITLE
feat(eldritch): support AAAA, TXT, MX, SOA, NS, PTR, AXFR, SRV records

### DIFF
--- a/docs/_docs/user-guide/eldritch.md
+++ b/docs/_docs/user-guide/eldritch.md
@@ -636,7 +636,7 @@ The `dns` library enables DNS lookups within Eldritch scripts.
 `dns.list(domain: str, kind: Option<str>, nameserver: Option<str>) -> List<str>`
 
 The **dns.list** method resolves the given domain name to the specified DNS record type.
-It supports querying IPv4 addresses ("A") and aliases ("CNAME"). If `kind` is not provided, it defaults to "A".
+It natively supports querying `A`, `AAAA`, `CNAME`, `TXT`, `MX`, `SOA`, `NS`, `PTR`, `AXFR`, and `SRV` records. If `kind` is not provided, it defaults to "A".
 An optional nameserver IP (e.g. "8.8.8.8") can be provided to query a specific DNS server instead of the system default.
 
 ```python

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/fake.rs
@@ -19,7 +19,19 @@ impl DnsLibrary for DnsLibraryFake {
             .to_uppercase();
         match rtype.as_str() {
             "A" => Ok(alloc::vec!["127.0.0.1".into(), "10.0.0.1".into()]),
+            "AAAA" => Ok(alloc::vec!["::1".into()]),
             "CNAME" => Ok(alloc::vec!["alias.example.com".into()]),
+            "TXT" => Ok(alloc::vec!["v=spf1 -all".into()]),
+            "MX" => Ok(alloc::vec!["10 mail.example.com".into()]),
+            "SOA" => Ok(alloc::vec![
+                "ns1.example.com admin.example.com 2026 7200 3600 1209600 3600".into()
+            ]),
+            "NS" => Ok(alloc::vec!["ns1.example.com".into()]),
+            "PTR" => Ok(alloc::vec!["google.com".into()]),
+            "AXFR" => Ok(alloc::vec![
+                "example.com 86400 IN SOA ns1.example.com".into()
+            ]),
+            "SRV" => Ok(alloc::vec!["10 50 5060 sip.example.com".into()]),
             _ => Err(alloc::format!("Unsupported record type: {}", rtype)),
         }
     }

--- a/implants/lib/eldritch/stdlib/eldritch-libdns/src/std/mod.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libdns/src/std/mod.rs
@@ -36,7 +36,15 @@ impl DnsLibrary for StdDnsLibrary {
         let rtype = kind.unwrap_or_else(|| alloc::string::String::from("A"));
         match rtype.to_uppercase().as_str() {
             "A" => resolve_a_records(&resolver, &domain),
+            "AAAA" => resolve_aaaa_records(&resolver, &domain),
             "CNAME" => resolve_cname_records(&resolver, &domain),
+            "TXT" => resolve_txt_records(&resolver, &domain),
+            "MX" => resolve_mx_records(&resolver, &domain),
+            "SOA" => resolve_soa_records(&resolver, &domain),
+            "NS" => resolve_ns_records(&resolver, &domain),
+            "PTR" => resolve_ptr_records(&resolver, &domain),
+            "AXFR" => resolve_axfr_records(&resolver, &domain),
+            "SRV" => resolve_srv_records(&resolver, &domain),
             _ => Err(format!("Unsupported record type: {}", rtype)),
         }
     }
@@ -49,9 +57,65 @@ fn resolve_a_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, S
     Ok(response.iter().map(|ip| ip.to_string()).collect())
 }
 
+fn resolve_aaaa_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .ipv6_lookup(domain)
+        .map_err(|e| format!("Failed to resolve AAAA records for {}: {}", domain, e))?;
+    Ok(response.iter().map(|ip| ip.to_string()).collect())
+}
+
 fn resolve_cname_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
     let response = resolver
         .lookup(domain, hickory_resolver::proto::rr::RecordType::CNAME)
         .map_err(|e| format!("Failed to resolve CNAME for {}: {}", domain, e))?;
     Ok(response.iter().map(|ip| ip.to_string()).collect())
+}
+
+fn resolve_txt_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .txt_lookup(domain)
+        .map_err(|e| format!("Failed to resolve TXT for {}: {}", domain, e))?;
+    Ok(response.iter().map(|t| t.to_string()).collect())
+}
+
+fn resolve_mx_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .mx_lookup(domain)
+        .map_err(|e| format!("Failed to resolve MX for {}: {}", domain, e))?;
+    Ok(response.iter().map(|m| m.to_string()).collect())
+}
+
+fn resolve_soa_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .lookup(domain, hickory_resolver::proto::rr::RecordType::SOA)
+        .map_err(|e| format!("Failed to resolve SOA for {}: {}", domain, e))?;
+    Ok(response.iter().map(|r| r.to_string()).collect())
+}
+
+fn resolve_ns_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .lookup(domain, hickory_resolver::proto::rr::RecordType::NS)
+        .map_err(|e| format!("Failed to resolve NS for {}: {}", domain, e))?;
+    Ok(response.iter().map(|r| r.to_string()).collect())
+}
+
+fn resolve_ptr_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .lookup(domain, hickory_resolver::proto::rr::RecordType::PTR)
+        .map_err(|e| format!("Failed to resolve PTR for {}: {}", domain, e))?;
+    Ok(response.iter().map(|r| r.to_string()).collect())
+}
+
+fn resolve_axfr_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .lookup(domain, hickory_resolver::proto::rr::RecordType::AXFR)
+        .map_err(|e| format!("Failed to resolve AXFR for {}: {}", domain, e))?;
+    Ok(response.iter().map(|r| r.to_string()).collect())
+}
+
+fn resolve_srv_records(resolver: &Resolver, domain: &str) -> Result<Vec<String>, String> {
+    let response = resolver
+        .lookup(domain, hickory_resolver::proto::rr::RecordType::SRV)
+        .map_err(|e| format!("Failed to resolve SRV for {}: {}", domain, e))?;
+    Ok(response.iter().map(|r| r.to_string()).collect())
 }


### PR DESCRIPTION
# Expand `dns.list` Native Record Support (AAAA, TXT, MX, SOA, NS, PTR, AXFR, SRV)

### Overview
This PR significantly expands our recently overhauled `dns.list` standard library method. Operators are no longer constrained explicitly to IPv4 (`A`) or `CNAME` domains. We have wired standard underlying bindings via the `hickory-resolver` to universally support an extensive array of DNS lookup types dynamically through the same lightweight parameter invocation interface (`dns.list("domain.net", kind="MX")`).

### Key Additions
* **Universal Record Extraction**: Added explicit, strongly-typed internal resolution handlers for:
    * `AAAA` (IPv6 Addresses)
    * `TXT` (General Text / Verification chains)
    * `MX` (Mail Exchangers)
    * `SOA` (Start of Authority Blocks)
    * `NS` (Authoritative Name Servers)
    * `PTR` (Reverse mapping pointers)
    * `AXFR` (Zone Transfers — Please note that this will be susceptible to standard remote TCP networking constraints and ACL rejections).
    * `SRV` (Service locators)
* **Testing & `fake` Layer Extensions**: Expanded the `DnsLibraryFake` environment to cleanly return mocked dummy blocks appropriately mimicking the expected structures for all newly integrated types, successfully guarding WASM/Integration runtimes. 
* **Documentation Visibility**: Thoroughly updated `docs/_docs/user-guide/eldritch.md` specifying all supported types for operator visibility.

### Verification Matrix
- [x] Compilation validates locally against `cargo check -p eldritch-libdns`
- [x] Internal framework assertions validate cleanly via `cargo test -p eldritch`
- [x] Code correctly aligned via `cargo fmt` hooks organically
