### PR TITLE
Fix duplicate HOST_ACCESS_NEW events

### DIFF
--- a/tavern/internal/ent/hook_events.go
+++ b/tavern/internal/ent/hook_events.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent"
 	"realm.pub/tavern/internal/ent/event"
+	"realm.pub/tavern/internal/ent/host"
 	"realm.pub/tavern/internal/ent/quest"
 	"realm.pub/tavern/internal/ent/task"
 )
@@ -55,6 +56,25 @@ func HookDeriveHostEvents() ent.Hook {
 				}
 
 				client := mut.Client()
+
+				if shouldCreateNew {
+					exists, err := client.Event.Query().
+						Where(
+							event.HasHostWith(host.ID(id)),
+							event.KindEQ(event.KindHOST_ACCESS_NEW),
+						).Exist(ctx)
+					if err != nil {
+						return nil, fmt.Errorf("checking for existing host access event: %w", err)
+					}
+					if exists {
+						shouldCreateNew = false
+					}
+				}
+
+				if !shouldCreateNew && !shouldCreateRecovered {
+					return val, nil
+				}
+
 				evtCreate := client.Event.Create().
 					SetTimestamp(time.Now().Unix()).
 					SetHostID(id)


### PR DESCRIPTION
The `HOST_ACCESS_NEW` event was firing multiple times for the same host because the C2 server uses upserts during host registration, which triggers the `OpCreate` hook in Ent every time. This change adds a database check within the hook to ensure the event hasn't already been created for the host.

---
*PR created automatically by Jules for task [10110650567524296428](https://jules.google.com/task/10110650567524296428) started by @KCarretto*