### PR TITLE
Update Go tests to use on-disk temporary databases

### DIFF
--- a/tavern/cli/auth/auth_test.go
+++ b/tavern/cli/auth/auth_test.go
@@ -35,11 +35,8 @@ func TestTokenAuthenticate(t *testing.T) {
 func TestAuthenticate(t *testing.T) {
 	// Setup Dependencies
 	ctx := context.Background()
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Create Test User

--- a/tavern/internal/auth/context_edge_cases_test.go
+++ b/tavern/internal/auth/context_edge_cases_test.go
@@ -12,11 +12,8 @@ import (
 
 func TestContextFromTokens_Invalid(t *testing.T) {
 	// Setup Dependencies
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Test ContextFromSessionToken with invalid token

--- a/tavern/internal/auth/context_test.go
+++ b/tavern/internal/auth/context_test.go
@@ -14,11 +14,8 @@ import (
 func TestContextFromSessionToken(t *testing.T) {
 	// Setup Dependencies
 	ctx := context.Background()
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Test Data
@@ -103,11 +100,8 @@ func TestContextFromSessionToken(t *testing.T) {
 func TestContextFromAccessToken(t *testing.T) {
 	// Setup Dependencies
 	ctx := context.Background()
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Test Data

--- a/tavern/internal/auth/oauth_test.go
+++ b/tavern/internal/auth/oauth_test.go
@@ -89,7 +89,7 @@ func TestNewOAuthAuthorizationHandler(t *testing.T) {
 		profileResp          = []byte(`{"sub":"goofygoober","picture":"photos.com/goofygoober","email":"goofygoober@google.com","name":"Mr. Goober","email_verified":true}`)
 	)
 	// Setup Test DB
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Setup Mock IDP
@@ -228,7 +228,7 @@ func TestNewOAuthAuthorizationHandler_DBError(t *testing.T) {
 		profileResp          = []byte(`{"sub":"goofygoober","picture":"photos.com/goofygoober","email":"goofygoober@google.com","name":"Mr. Goober","email_verified":true}`)
 	)
 	// Setup Test DB
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	// We deliberately close the graph to trigger a DB error during query
 	graph.Close()
 

--- a/tavern/internal/auth/token_auth_test.go
+++ b/tavern/internal/auth/token_auth_test.go
@@ -17,11 +17,8 @@ import (
 func TestNewTokenRedirectHandler(t *testing.T) {
 	// Setup Dependencies
 	ctx := context.Background()
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 	handler := auth.NewTokenRedirectHandler()
 

--- a/tavern/internal/builder/executor_integration_test.go
+++ b/tavern/internal/builder/executor_integration_test.go
@@ -31,7 +31,7 @@ func TestExecutorIntegration_ClaimAndExecuteWithMock(t *testing.T) {
 	ctx := context.Background()
 
 	// Full infrastructure setup
-	graph := enttest.Open(t, "sqlite3", "file:ent_claim_exec?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	_, caPrivKey, err := ed25519.GenerateKey(rand.Reader)
@@ -183,7 +183,7 @@ func TestExecutorIntegration_ClaimAndExecuteWithMock(t *testing.T) {
 func TestExecutorIntegration_ClaimAndExecuteWithMockError(t *testing.T) {
 	ctx := context.Background()
 
-	graph := enttest.Open(t, "sqlite3", "file:ent_claim_exec_err?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	_, caPrivKey, err := ed25519.GenerateKey(rand.Reader)
@@ -336,7 +336,7 @@ func TestExecutorIntegration_ClaimAndExecuteWithMockError(t *testing.T) {
 func TestExecutorIntegration_StreamBuildOutput(t *testing.T) {
 	ctx := context.Background()
 
-	graph := enttest.Open(t, "sqlite3", "file:ent_stream_output?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	_, caPrivKey, err := ed25519.GenerateKey(rand.Reader)
@@ -470,7 +470,7 @@ func TestExecutorIntegration_StreamBuildOutput(t *testing.T) {
 func TestExecutorIntegration_StreamBuildOutputWithError(t *testing.T) {
 	ctx := context.Background()
 
-	graph := enttest.Open(t, "sqlite3", "file:ent_stream_output_err?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	_, caPrivKey, err := ed25519.GenerateKey(rand.Reader)
@@ -601,7 +601,7 @@ func TestExecutorIntegration_StreamBuildOutputWithError(t *testing.T) {
 func TestExecutorIntegration_UploadBuildArtifact(t *testing.T) {
 	ctx := context.Background()
 
-	graph := enttest.Open(t, "sqlite3", "file:ent_upload_artifact?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	_, caPrivKey, err := ed25519.GenerateKey(rand.Reader)

--- a/tavern/internal/builder/integration_test.go
+++ b/tavern/internal/builder/integration_test.go
@@ -31,7 +31,7 @@ func TestBuilderE2E(t *testing.T) {
 	ctx := context.Background()
 
 	// 1. Setup in-memory SQLite database
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// 2. Generate ED25519 key pair and create Builder CA

--- a/tavern/internal/c2/c2test/grpc.go
+++ b/tavern/internal/c2/c2test/grpc.go
@@ -30,14 +30,8 @@ func New(t *testing.T) (c2pb.C2Client, *ent.Client, func(), string) {
 	t.Helper()
 	ctx := context.Background()
 
-	// TestDB Config
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-
 	// Ent Client
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+	graph := enttest.OpenTempDB(t)
 
 	// gRPC Mux
 	var (

--- a/tavern/internal/c2/reverse_shell_e2e_test.go
+++ b/tavern/internal/c2/reverse_shell_e2e_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestReverseShell_E2E(t *testing.T) {
 	// Setup Ent Client
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tavern/internal/c2/tome_automation_test.go
+++ b/tavern/internal/c2/tome_automation_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestHandleTomeAutomation(t *testing.T) {
 	ctx := context.Background()
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	srv := &Server{graph: client}
@@ -185,7 +185,7 @@ func TestHandleTomeAutomation(t *testing.T) {
 
 func TestHandleTomeAutomation_Deduplication(t *testing.T) {
 	ctx := context.Background()
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	srv := &Server{graph: client}
@@ -227,7 +227,7 @@ func TestHandleTomeAutomation_Deduplication(t *testing.T) {
 
 func TestHandleTomeAutomation_IntervalWindow(t *testing.T) {
 	ctx := context.Background()
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	srv := &Server{graph: client}
@@ -282,7 +282,7 @@ func TestHandleTomeAutomation_IntervalWindow(t *testing.T) {
 
 func TestHandleTomeAutomation_CronRange(t *testing.T) {
 	ctx := context.Background()
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	srv := &Server{graph: client}

--- a/tavern/internal/cdn/download_hostfile_test.go
+++ b/tavern/internal/cdn/download_hostfile_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestDownloadHostFile asserts that the download handler exhibits expected behavior.
 func TestDownloadHostFile(t *testing.T) {
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	ctx := context.Background()

--- a/tavern/internal/cdn/download_test.go
+++ b/tavern/internal/cdn/download_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestDownload asserts that the download handler exhibits expected behavior.
 func TestDownload(t *testing.T) {
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	expectedContent := []byte("file_content")

--- a/tavern/internal/cdn/upload_test.go
+++ b/tavern/internal/cdn/upload_test.go
@@ -23,7 +23,7 @@ import (
 
 // TestUpload asserts that the upload handler exhibits expected behavior.
 func TestUpload(t *testing.T) {
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	expectedContent := []byte("file_content")

--- a/tavern/internal/ent/enttest/testdb.go
+++ b/tavern/internal/ent/enttest/testdb.go
@@ -1,0 +1,72 @@
+package enttest
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"realm.pub/tavern/internal/ent"
+	entsql "entgo.io/ent/dialect/sql"
+
+	// The mattn driver
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// NewDB creates a new on-disk temporary SQLite database for testing.
+// It enables WAL mode, sets a busy timeout, and tunes the connection pool.
+// It also registers a cleanup function to remove the database files after the test.
+func NewDB(t testing.TB) *sql.DB {
+	// 1. Create the RAM-backed temp file
+	file, err := os.CreateTemp("", "tavern-*.db")
+	if err != nil {
+		t.Fatalf("failed to create temp db: %v", err)
+	}
+	file.Close()
+
+	// 2. The Magic DSN for mattn
+	// _journal=WAL: Enables concurrent readers/writer
+	// _busy_timeout=10000: Forces SQLite to wait 10 seconds for a write lock before failing
+	// _fk=1: Enables foreign keys (often needed for Realm)
+	// _sync=NORMAL: Speeds up WAL mode safely
+	dsn := "file:" + file.Name() + "?_journal=WAL&_busy_timeout=10000&_fk=1&_sync=NORMAL"
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	// Clean up the main db, WAL file, and Shared Memory file
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(file.Name())
+		os.Remove(file.Name() + "-wal")
+		os.Remove(file.Name() + "-shm")
+	})
+
+	// 3. CRITICAL: Tune the Go Connection Pool
+	// Limit open connections to prevent Go from overwhelming SQLite's queue
+	db.SetMaxOpenConns(10)
+	// Keep idle connections low to prevent stale CGO threads
+	db.SetMaxIdleConns(2)
+
+	return db
+}
+
+// OpenTempDB creates a new ent.Client attached to an on-disk temporary SQLite database.
+func OpenTempDB(t testing.TB, opts ...Option) *ent.Client {
+	client, _ := OpenTempDBWithDB(t, opts...)
+	return client
+}
+
+// OpenTempDBWithDB creates a new ent.Client and returns it along with the underlying sql.DB.
+func OpenTempDBWithDB(t testing.TB, opts ...Option) (*ent.Client, *sql.DB) {
+	db := NewDB(t)
+	drv := entsql.OpenDB("sqlite3", db)
+
+	o := newOptions(opts)
+	client := ent.NewClient(append(o.opts, ent.Driver(drv))...)
+
+	migrateSchema(t, client, o)
+
+	return client, db
+}

--- a/tavern/internal/ent/hook_events_test.go
+++ b/tavern/internal/ent/hook_events_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHookDeriveNotifications(t *testing.T) {
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	// Add the hooks since enttest.Open doesn't by default

--- a/tavern/internal/ent/schema/asset_test.go
+++ b/tavern/internal/ent/schema/asset_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAssetHooks(t *testing.T) {
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	var (
@@ -37,7 +37,7 @@ func TestAssetHooks(t *testing.T) {
 
 func TestMultipleTomes(t *testing.T) {
 	ctx := context.Background()
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	assets := []*ent.Asset{

--- a/tavern/internal/ent/schema/host_file_test.go
+++ b/tavern/internal/ent/schema/host_file_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHostFileHooks(t *testing.T) {
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	var (

--- a/tavern/internal/ent/schema/link_test.go
+++ b/tavern/internal/ent/schema/link_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestCreateLinkWithExplicitExpiresAt verifies that explicitly setting expiresAt works correctly.
 func TestCreateLinkWithExplicitExpiresAt(t *testing.T) {
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	ctx := context.Background()

--- a/tavern/internal/graphql/api_test.go
+++ b/tavern/internal/graphql/api_test.go
@@ -2,7 +2,6 @@ package graphql_test
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -61,12 +60,6 @@ func (fake importerFake) Import(ctx context.Context, repo *ent.Repository, filte
 func runTestCase(t *testing.T, path string) {
 	t.Helper()
 
-	// TestDB Config
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-
 	// Read Test Case
 	tcBytes, err := os.ReadFile(path)
 	require.NoError(t, err, "failed to read test case %q", path)
@@ -80,13 +73,9 @@ func runTestCase(t *testing.T, path string) {
 	expectedJSON, err := json.Marshal(tc.Expected)
 	require.NoError(t, err)
 
-	// Ent Client
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+	// Ent Client & Initial DB State
+	graph, db := enttest.OpenTempDBWithDB(t)
 	defer graph.Close()
-
-	// Initial DB State
-	db, err := sql.Open(driverName, dataSourceName)
-	require.NoError(t, err, "failed to open test db")
 	defer db.Close()
 	_, dbErr := db.Exec(tc.State)
 	require.NoError(t, dbErr, "failed to setup test db state")

--- a/tavern/internal/graphql/build_task_test.go
+++ b/tavern/internal/graphql/build_task_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestCreateBuildTask(t *testing.T) {
 	ctx := context.Background()
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	git := tomes.NewGitImporter(graph)

--- a/tavern/internal/graphql/metrics_test.go
+++ b/tavern/internal/graphql/metrics_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMetrics_QuestTimelineChart(t *testing.T) {
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	ctx := context.Background()

--- a/tavern/internal/graphql/quest_test.go
+++ b/tavern/internal/graphql/quest_test.go
@@ -25,7 +25,7 @@ import (
 func TestCreateQuest(t *testing.T) {
 	// Setup
 	ctx := context.Background()
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Initialize Git Importer

--- a/tavern/internal/graphql/tome_test.go
+++ b/tavern/internal/graphql/tome_test.go
@@ -18,7 +18,7 @@ import (
 func TestTomeMutations(t *testing.T) {
 	// Setup
 	ctx := context.Background()
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Initialize Git Importer

--- a/tavern/internal/graphql/user_test.go
+++ b/tavern/internal/graphql/user_test.go
@@ -21,7 +21,7 @@ import (
 func TestUserMutations(t *testing.T) {
 	// Setup
 	ctx := context.Background()
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Initialize Git Importer

--- a/tavern/internal/http/auth_test.go
+++ b/tavern/internal/http/auth_test.go
@@ -16,11 +16,8 @@ import (
 func TestRequestAuthenticator(t *testing.T) {
 	// Setup Dependencies
 	ctx := context.Background()
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 	srv := tavernhttp.NewServer(
 		tavernhttp.RouteMap{

--- a/tavern/internal/http/shell/integration_test.go
+++ b/tavern/internal/http/shell/integration_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"database/sql"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
@@ -20,6 +19,7 @@ import (
 	"realm.pub/tavern/internal/auth"
 	"realm.pub/tavern/internal/c2/c2pb"
 	"realm.pub/tavern/internal/ent"
+	"realm.pub/tavern/internal/ent/enttest"
 	"realm.pub/tavern/internal/http/shell"
 	"realm.pub/tavern/internal/portals/mux"
 	"realm.pub/tavern/portals/portalpb"
@@ -49,12 +49,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 	ctx := context.Background()
 
 	// 1. Setup DB
-	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1&_busy_timeout=30000", uuid.NewString())
-
-	db, err := sql.Open("sqlite3", dsn)
-	require.NoError(t, err)
-	db.SetMaxOpenConns(1)
-
+	db := enttest.NewDB(t)
 	drv := entsql.OpenDB("sqlite3", db)
 	entClient := ent.NewClient(ent.Driver(drv))
 

--- a/tavern/internal/http/stream/websocket_test.go
+++ b/tavern/internal/http/stream/websocket_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNewShellHandler(t *testing.T) {
 	// Setup Ent Client
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/tavern/internal/portals/benchmark_test.go
+++ b/tavern/internal/portals/benchmark_test.go
@@ -42,7 +42,7 @@ func newBufListener(sz int) *bufListener {
 
 func BenchmarkPortalThroughput(b *testing.B) {
 	// 1. Setup DB
-	client := enttest.Open(b, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(b)
 	defer client.Close()
 
 	ctx := context.Background()

--- a/tavern/internal/portals/integration_test.go
+++ b/tavern/internal/portals/integration_test.go
@@ -58,8 +58,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 	ctx := context.Background()
 
 	// 1. Setup DB
-	dsn := fmt.Sprintf("file:ent_%s?mode=memory&cache=shared&_fk=1", t.Name())
-	entClient := enttest.Open(t, "sqlite3", dsn)
+	entClient := enttest.OpenTempDB(t)
 
 	// 2. Setup Portal Mux (In-Memory)
 	portalMux := mux.New()

--- a/tavern/internal/portals/mux/benchmark_test.go
+++ b/tavern/internal/portals/mux/benchmark_test.go
@@ -14,7 +14,7 @@ import (
 
 func BenchmarkMuxThroughput(b *testing.B) {
 	// Setup DB
-	client := enttest.Open(b, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(b)
 	defer client.Close()
 
 	// Setup Mux

--- a/tavern/internal/portals/mux/mux_test.go
+++ b/tavern/internal/portals/mux/mux_test.go
@@ -74,7 +74,7 @@ func TestMux_InMemory(t *testing.T) {
 
 func TestMux_CreatePortal(t *testing.T) {
 	// Setup DB
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	// Setup Mux
@@ -200,7 +200,7 @@ func TestWithSubscriberBufferSize(t *testing.T) {
 
 func TestMux_CreatePortal_ShellTask(t *testing.T) {
 	// Setup DB
-	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client := enttest.OpenTempDB(t)
 	defer client.Close()
 
 	// Setup Mux

--- a/tavern/test_data_test.go
+++ b/tavern/test_data_test.go
@@ -15,10 +15,8 @@ import (
 func TestCreateTestData(t *testing.T) {
 	var (
 		ctx            = context.Background()
-		driverName     = "sqlite3"
-		dataSourceName = "file:test-create-test-data?mode=memory&cache=shared&_fk=1"
 	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	createTestData(ctx, graph)

--- a/tavern/tomes/git_test.go
+++ b/tavern/tomes/git_test.go
@@ -57,11 +57,8 @@ func TestImportFromRepo(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	var (
-		driverName     = "sqlite3"
-		dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-	)
-	graph := enttest.Open(t, driverName, dataSourceName, enttest.WithOptions())
+
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Initialize Git Importer

--- a/tavern/tomes/parse_test.go
+++ b/tavern/tomes/parse_test.go
@@ -17,7 +17,7 @@ import (
 func TestUploadTomes(t *testing.T) {
 	// Setup
 	ctx := context.Background()
-	graph := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	graph := enttest.OpenTempDB(t)
 	defer graph.Close()
 
 	// Assert our example tome is there


### PR DESCRIPTION
Updated Go tests to use on-disk temporary SQLite databases with WAL mode and connection pool tuning to resolve concurrency issues. Introduced centralized helpers in `enttest` package and refactored existing tests.

---
*PR created automatically by Jules for task [14797915500560428914](https://jules.google.com/task/14797915500560428914) started by @KCarretto*