### PR TITLE
[AI] Display beacon principal in shellv2 top bar

### DIFF
--- a/tavern/internal/www/src/pages/shellv2/components/ShellHeader.tsx
+++ b/tavern/internal/www/src/pages/shellv2/components/ShellHeader.tsx
@@ -31,30 +31,33 @@ const ShellHeader: React.FC<ShellHeaderProps> = ({ shellData, activeUsers = [] }
     <div className="flex items-center gap-4 mb-4">
       <Breadcrumbs pages={[{ label: "Shell", link: window.location.pathname }]} />
       <Badge badgeStyle={{ color: "red" }}>BETA</Badge>
-      <h1 className="text-xl font-bold">
-        <Tooltip label={
-          <div className="flex flex-col">
-            <span>Principal: {principal}</span>
-            <span>Agent Identifier: {agentIdentifier}</span>
-            <span>Interval: {interval}</span>
-            <span>Transport: {getEnumKey(SupportedTransports, transport)}</span>
-          </div>
-        }>
-          <span className="cursor-help border-b border-dashed border-gray-500">{beaconName}</span>
-        </Tooltip>
-        {" @ "}
-        <Tooltip label={
-          <div className="flex flex-col">
-            <span>Primary IP: {primaryIP}</span>
-            <span>External IP: {externalIP}</span>
-            <span>Platform: {getEnumKey(SupportedPlatforms, platform)}</span>
-            {tags.length > 0 && (
-              <span>Tags: {tags.map((t: any) => t.name).join(', ')}</span>
-            )}
-          </div>
-        }>
-          <Link to={`/hosts/${hostId}`} className="text-blue-400 hover:text-blue-300 underline">{hostName}</Link>
-        </Tooltip>
+      <h1 className="text-xl font-bold flex items-center gap-2">
+        <span>
+          <Tooltip label={
+            <div className="flex flex-col">
+              <span>Principal: {principal}</span>
+              <span>Agent Identifier: {agentIdentifier}</span>
+              <span>Interval: {interval}</span>
+              <span>Transport: {getEnumKey(SupportedTransports, transport)}</span>
+            </div>
+          }>
+            <span className="cursor-help border-b border-dashed border-gray-500">{beaconName}</span>
+          </Tooltip>
+          {" @ "}
+          <Tooltip label={
+            <div className="flex flex-col">
+              <span>Primary IP: {primaryIP}</span>
+              <span>External IP: {externalIP}</span>
+              <span>Platform: {getEnumKey(SupportedPlatforms, platform)}</span>
+              {tags.length > 0 && (
+                <span>Tags: {tags.map((t: any) => t.name).join(', ')}</span>
+              )}
+            </div>
+          }>
+            <Link to={`/hosts/${hostId}`} className="text-blue-400 hover:text-blue-300 underline">{hostName}</Link>
+          </Tooltip>
+        </span>
+        {principal && <Badge>{principal}</Badge>}
       </h1>
       <a
         href="https://github.com/spellshift/realm/issues/new?template=bug_report.md&labels=bug&title=%5Bbug%5D%20Shell%3A%20%3CYOUR%20ISSUE%3E"

--- a/tavern/internal/www/src/pages/shellv2/components/__tests__/ShellHeader.test.tsx
+++ b/tavern/internal/www/src/pages/shellv2/components/__tests__/ShellHeader.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import ShellHeader from "../ShellHeader";
+import React from "react";
+import { expect, describe, it, vi } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import "@testing-library/jest-dom";
+
+// Mock Tooltip because it often causes issues in tests
+vi.mock("@chakra-ui/react", async () => {
+    const actual = await vi.importActual("@chakra-ui/react");
+    return {
+        ...actual,
+        Tooltip: ({ children, label }: any) => <div title={typeof label === 'string' ? label : "tooltip"}>{children}</div>,
+    };
+});
+
+describe("ShellHeader", () => {
+    const mockShellData = {
+        node: {
+            beacon: {
+                name: "test-beacon",
+                principal: "root",
+                agentIdentifier: "agent-1",
+                interval: 60,
+                transport: "HTTP",
+                host: {
+                    id: "host-1",
+                    name: "test-host",
+                    primaryIP: "192.168.1.1",
+                    externalIP: "8.8.8.8",
+                    platform: "linux",
+                    tags: { edges: [] }
+                }
+            }
+        }
+    };
+
+    it("renders beacon name and host name", () => {
+        render(
+            <BrowserRouter>
+                <ShellHeader shellData={mockShellData} />
+            </BrowserRouter>
+        );
+        expect(screen.getByText("test-beacon")).toBeInTheDocument();
+        expect(screen.getByText("test-host")).toBeInTheDocument();
+    });
+
+    it("renders principal badge when present", () => {
+        render(
+            <BrowserRouter>
+                <ShellHeader shellData={mockShellData} />
+            </BrowserRouter>
+        );
+        expect(screen.getByText("root")).toBeInTheDocument();
+    });
+
+    it("does not render principal badge when absent", () => {
+        const dataWithoutPrincipal = {
+            node: {
+                ...mockShellData.node,
+                beacon: {
+                    ...mockShellData.node.beacon,
+                    principal: null
+                }
+            }
+        };
+        render(
+            <BrowserRouter>
+                <ShellHeader shellData={dataWithoutPrincipal} />
+            </BrowserRouter>
+        );
+        expect(screen.queryByText("root")).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
This PR updates the Shell v2 interface to make the beacon principal (the user identity the agent is running as) visible in the top bar. This improves visibility of the execution context without needing to hover over the beacon name.

Key changes:
- `ShellHeader.tsx` now conditionally renders a `Badge` containing the principal next to the beacon/host information.
- A new test file `ShellHeader.test.tsx` was added to ensure the header renders correctly with and without a principal.

---
*PR created automatically by Jules for task [16737458075365606044](https://jules.google.com/task/16737458075365606044) started by @KCarretto*