### PR TITLE
Add "Create Portal" button to portals tab

### DIFF
--- a/tavern/internal/www/src/components/tavern-base-ui/virtualized-table/VirtualizedTableWrapper.tsx
+++ b/tavern/internal/www/src/components/tavern-base-ui/virtualized-table/VirtualizedTableWrapper.tsx
@@ -13,6 +13,8 @@ export const VirtualizedTableWrapper: React.FC<VirtualizedTableWrapperProps> = (
     table,
     sortType,
     showFiltering = true,
+    actions,
+    emptyStateAction,
 }) => {
     const { filterCount, resetFilters } = useFilters();
 
@@ -58,7 +60,9 @@ export const VirtualizedTableWrapper: React.FC<VirtualizedTableWrapperProps> = (
                 <EmptyState
                     type={EmptyStateType.noData}
                     label="No data found"
-                />
+                >
+                    {emptyStateAction}
+                </EmptyState>
             );
         }
 
@@ -75,6 +79,7 @@ export const VirtualizedTableWrapper: React.FC<VirtualizedTableWrapperProps> = (
                     <p className='text-md text-gray-600'>{totalItems !== undefined && `(${totalItems})`}</p>
                 </div>
                 <div className="flex flex-row justify-end gap-2 w-full md:w-auto">
+                    {actions}
                     {sortType && <SortingControls sortType={sortType} />}
                     {showFiltering && <FilterControls />}
                 </div>

--- a/tavern/internal/www/src/components/tavern-base-ui/virtualized-table/types.ts
+++ b/tavern/internal/www/src/components/tavern-base-ui/virtualized-table/types.ts
@@ -26,6 +26,12 @@ export interface VirtualizedTableWrapperProps {
 
     /** Whether to show filtering controls */
     showFiltering?: boolean;
+
+    /** Optional additional actions to display in the header */
+    actions?: ReactNode;
+
+    /** Optional action to display in the empty state */
+    emptyStateAction?: ReactNode;
 }
 
 /**

--- a/tavern/internal/www/src/pages/host-details/portal-tab/CreatePortalQuestButton.tsx
+++ b/tavern/internal/www/src/pages/host-details/portal-tab/CreatePortalQuestButton.tsx
@@ -1,0 +1,34 @@
+import Button from "../../../components/tavern-base-ui/button/Button";
+import { useCreateQuestModal } from "../../../context/CreateQuestModalContext";
+import { usePortalQuestFormData } from "./usePortalQuestFormData";
+import { PlusIcon } from "lucide-react";
+
+interface CreatePortalQuestButtonProps {
+    variant?: "solid" | "ghost";
+    size?: "sm" | "md" | "lg" | "xs";
+}
+
+export const CreatePortalQuestButton = ({ variant = "solid", size = "md" }: CreatePortalQuestButtonProps) => {
+    const { openModal } = useCreateQuestModal();
+    const { fetchFormData, loading } = usePortalQuestFormData();
+
+    const handleClick = async () => {
+        const initialFormData = await fetchFormData();
+        openModal({
+            initialFormData,
+            refetchQueries: ["GetHostContext", "GetPortalIds"],
+        });
+    };
+
+    return (
+        <Button
+            leftIcon={<PlusIcon className="w-4 h-4" />}
+            onClick={handleClick}
+            buttonVariant={variant}
+            buttonStyle={{ color: variant === "solid" ? "purple" : "gray", size }}
+            disabled={loading}
+        >
+            {loading ? "Loading..." : "Create Portal"}
+        </Button>
+    );
+};

--- a/tavern/internal/www/src/pages/host-details/portal-tab/PortalTab.tsx
+++ b/tavern/internal/www/src/pages/host-details/portal-tab/PortalTab.tsx
@@ -5,6 +5,7 @@ import { PortalsTable } from "./PortalsTable";
 import { usePortalIds } from "./usePortalIds";
 import { useParams } from "react-router-dom";
 import Button from "../../../components/tavern-base-ui/button/Button";
+import { CreatePortalQuestButton } from "./CreatePortalQuestButton";
 
 const PortalsHeader = () => {
     const [downloadAsset, setDownloadAsset] = useState<string>("linux/socks5");
@@ -63,6 +64,8 @@ const PortalTab = () => {
                 loading={initialLoading}
                 error={error}
                 showFiltering={false}
+                actions={<CreatePortalQuestButton variant="ghost" size="sm" />}
+                emptyStateAction={<CreatePortalQuestButton variant="solid" size="md" />}
                 table={
                     <PortalsTable
                         portalIds={portalIds}

--- a/tavern/internal/www/src/pages/host-details/portal-tab/usePortalQuestFormData.ts
+++ b/tavern/internal/www/src/pages/host-details/portal-tab/usePortalQuestFormData.ts
@@ -1,0 +1,86 @@
+import { useCallback, useMemo } from "react";
+import { useQuery, useLazyQuery } from "@apollo/client";
+import { sub } from "date-fns";
+import { useHost } from "../../../context/HostContext";
+import { GET_TOME_IDS_QUERY } from "../../../utils/queries";
+import { GET_ONLINE_HOST_BEACONS_QUERY } from "../process-tab/queries";
+import { getPriotizedBeaconId } from "../../../utils/utils";
+import { CreateQuestInitialData } from "../../../context/CreateQuestModalContext";
+import {
+    TomeIdNode,
+    TomeIdsQueryTopLevel,
+    BeaconIdNode,
+    BeaconIdEdge,
+} from "../../../utils/interfacesQuery";
+import { Filters } from "../../../context/FilterContext";
+
+interface BeaconQueryResponse {
+    beacons: {
+        edges: BeaconIdEdge[];
+    };
+}
+
+function buildFormData(
+    hostName: string,
+    tome: TomeIdNode,
+    beacons: BeaconIdNode[],
+    initialFilters?: Partial<Filters>
+): CreateQuestInitialData {
+    const beaconId = getPriotizedBeaconId(beacons);
+
+    return {
+        name: `${hostName}: SOCKS5 Relay`,
+        tomeId: tome.id,
+        params: [],
+        beacons: beaconId ? [beaconId] : [],
+        initialFilters: initialFilters
+    };
+}
+
+export const usePortalQuestFormData = () => {
+    const { data: host } = useHost();
+
+    const { data: tomeData } = useQuery<TomeIdsQueryTopLevel>(GET_TOME_IDS_QUERY, {
+        variables: { where: { name: "SOCKS5 Relay" } },
+    });
+
+    const [fetchBeacons, { loading }] = useLazyQuery<BeaconQueryResponse>(
+        GET_ONLINE_HOST_BEACONS_QUERY,
+        { fetchPolicy: "network-only" }
+    );
+
+    const initialFilters = useMemo(() => {
+        if (!host) return undefined;
+        return {
+            beaconFields: [{
+                id: host.id,
+                name: host.name,
+                value: host.id,
+                label: host.name,
+                kind: "host",
+            }],
+            tomeMultiSearch: "SOCKS5 Relay"
+        };
+    }, [host]);
+
+    const fetchFormData = useCallback(async (): Promise<CreateQuestInitialData | undefined> => {
+        const tome = tomeData?.tomes?.edges?.[0]?.node;
+        if (!host?.id || !host?.name || !tome) return undefined;
+
+        const onlineThreshold = sub(new Date(), { seconds: 30 }).toISOString();
+
+        const { data: beaconData } = await fetchBeacons({
+            variables: {
+                where: {
+                    hasHostWith: { id: host.id },
+                    nextSeenAtGTE: onlineThreshold,
+                },
+            },
+        });
+
+        const beacons = beaconData?.beacons?.edges?.map((e) => e.node) || [];
+        return buildFormData(host.name, tome, beacons, initialFilters);
+    }, [host?.id, host?.name, tomeData, fetchBeacons, initialFilters]);
+
+    return { fetchFormData, loading };
+};

--- a/tavern_backend.log
+++ b/tavern_backend.log
@@ -1,0 +1,185 @@
+go: downloading go1.26.2 (linux/amd64)
+go: downloading contrib.go.opencensus.io/exporter/prometheus v0.4.2
+go: downloading cloud.google.com/go/pubsub/v2 v2.5.0
+go: downloading entgo.io/contrib v0.6.0
+go: downloading entgo.io/ent v0.14.1
+go: downloading cloud.google.com/go/pubsub v1.50.1
+go: downloading cloud.google.com/go v0.123.0
+go: downloading github.com/99designs/gqlgen v0.17.89
+go: downloading github.com/go-sql-driver/mysql v1.9.3
+go: downloading github.com/mattn/go-sqlite3 v1.14.16
+go: downloading github.com/prometheus/client_golang v1.20.4
+go: downloading github.com/urfave/cli v1.22.5
+go: downloading go.opencensus.io v0.24.0
+go: downloading gocloud.dev v0.40.0
+go: downloading golang.org/x/net v0.52.0
+go: downloading golang.org/x/oauth2 v0.36.0
+go: downloading google.golang.org/grpc v1.79.2
+go: downloading google.golang.org/protobuf v1.36.11
+go: downloading github.com/prometheus/statsd_exporter v0.22.7
+go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5
+go: downloading google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d
+go: downloading github.com/google/uuid v1.6.0
+go: downloading github.com/googleapis/gax-go/v2 v2.18.0
+go: downloading go.opentelemetry.io/otel v1.42.0
+go: downloading go.opentelemetry.io/otel/trace v1.42.0
+go: downloading golang.org/x/sync v0.20.0
+go: downloading google.golang.org/api v0.272.0
+go: downloading github.com/sosodev/duration v1.4.0
+go: downloading github.com/vektah/gqlparser/v2 v2.5.32
+go: downloading filippo.io/edwards25519 v1.1.0
+go: downloading github.com/vmihailenco/msgpack/v5 v5.4.1
+go: downloading golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+go: downloading github.com/beorn7/perks v1.0.1
+go: downloading github.com/cespare/xxhash/v2 v2.3.0
+go: downloading github.com/prometheus/client_model v0.6.1
+go: downloading github.com/prometheus/common v0.60.1
+go: downloading github.com/prometheus/procfs v0.15.1
+go: downloading github.com/klauspost/compress v1.17.11
+go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.6
+go: downloading github.com/google/wire v0.7.0
+go: downloading cloud.google.com/go/compute/metadata v0.9.0
+go: downloading github.com/golang-jwt/jwt/v5 v5.3.1
+go: downloading gopkg.in/yaml.v3 v3.0.1
+go: downloading github.com/robfig/cron/v3 v3.0.1
+go: downloading github.com/docker/docker v28.5.2+incompatible
+go: downloading github.com/cloudflare/circl v1.6.1
+go: downloading github.com/hashicorp/golang-lru/v2 v2.0.7
+go: downloading golang.org/x/crypto v0.49.0
+go: downloading github.com/gorilla/websocket v1.5.3
+go: downloading github.com/caddyserver/certmagic v0.25.2
+go: downloading cloud.google.com/go/secretmanager v1.16.0
+go: downloading github.com/go-git/go-git/v5 v5.12.0
+go: downloading github.com/hashicorp/go-multierror v1.1.1
+go: downloading github.com/go-kit/log v0.2.1
+go: downloading gopkg.in/yaml.v2 v2.4.0
+go: downloading cloud.google.com/go/iam v1.5.3
+go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20260311181403-84a4fc48630c
+go: downloading github.com/go-logr/logr v1.4.3
+go: downloading go.opentelemetry.io/otel/metric v1.42.0
+go: downloading github.com/go-viper/mapstructure/v2 v2.5.0
+go: downloading golang.org/x/tools v0.42.0
+go: downloading ariga.io/atlas v0.25.1-0.20240717145915-af51d3945208
+go: downloading github.com/go-openapi/inflect v0.21.0
+go: downloading github.com/goccy/go-yaml v1.19.2
+go: downloading github.com/vmihailenco/tagparser/v2 v2.0.0
+go: downloading github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+go: downloading golang.org/x/sys v0.42.0
+go: downloading github.com/russross/blackfriday/v2 v2.1.0
+go: downloading golang.org/x/text v0.35.0
+go: downloading golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
+go: downloading github.com/docker/go-connections v0.6.0
+go: downloading github.com/docker/go-units v0.5.0
+go: downloading github.com/moby/docker-image-spec v1.3.1
+go: downloading github.com/opencontainers/image-spec v1.1.1
+go: downloading github.com/opencontainers/go-digest v1.0.0
+go: downloading github.com/containerd/errdefs v1.0.0
+go: downloading github.com/containerd/errdefs/pkg v0.3.0
+go: downloading github.com/distribution/reference v0.6.0
+go: downloading github.com/pkg/errors v0.9.1
+go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0
+go: downloading go.einride.tech/aip v0.83.0
+go: downloading github.com/caddyserver/zerossl v0.1.5
+go: downloading github.com/klauspost/cpuid/v2 v2.3.0
+go: downloading github.com/libdns/libdns v1.1.1
+go: downloading github.com/mholt/acmez/v3 v3.1.6
+go: downloading github.com/miekg/dns v1.1.72
+go: downloading github.com/zeebo/blake3 v0.2.4
+go: downloading go.uber.org/zap v1.27.1
+go: downloading go.uber.org/zap/exp v0.3.0
+go: downloading cloud.google.com/go/auth v0.18.2
+go: downloading dario.cat/mergo v1.0.0
+go: downloading github.com/ProtonMail/go-crypto v1.1.6
+go: downloading github.com/go-git/go-billy/v5 v5.6.0
+go: downloading github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3
+go: downloading github.com/kevinburke/ssh_config v1.2.0
+go: downloading github.com/skeema/knownhosts v1.3.0
+go: downloading github.com/xanzy/ssh-agent v0.3.3
+go: downloading github.com/emirpasic/gods v1.18.1
+go: downloading github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
+go: downloading github.com/hashicorp/errwrap v1.1.0
+go: downloading cloud.google.com/go/auth/oauth2adapt v0.2.8
+go: downloading go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
+go: downloading golang.org/x/time v0.15.0
+go: downloading github.com/go-logfmt/logfmt v0.5.1
+go: downloading github.com/go-logr/stdr v1.2.2
+go: downloading go.opentelemetry.io/auto/sdk v1.2.1
+go: downloading github.com/agnivade/levenshtein v1.2.1
+go: downloading github.com/hashicorp/hcl/v2 v2.23.0
+go: downloading github.com/zclconf/go-cty v1.14.4
+go: downloading github.com/felixge/httpsnoop v1.0.4
+go: downloading github.com/google/go-cmp v0.7.0
+go: downloading go.opentelemetry.io/otel/sdk v1.42.0
+go: downloading go.uber.org/multierr v1.11.0
+go: downloading github.com/google/s2a-go v0.1.9
+go: downloading github.com/cyphar/filepath-securejoin v0.4.1
+go: downloading github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376
+go: downloading github.com/pjbgf/sha1cd v0.3.2
+go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
+go: downloading github.com/googleapis/enterprise-certificate-proxy v0.3.14
+go: downloading golang.org/x/mod v0.33.0
+go: downloading gopkg.in/warnings.v0 v0.1.2
+go: downloading github.com/agext/levenshtein v1.2.3
+go: downloading github.com/apparentlymart/go-textseg/v15 v15.0.0
+go: downloading github.com/mitchellh/go-wordwrap v1.0.1
+2026/04/15 00:10:22 WARN missing configuration, using default value env_var=ENABLE_DEBUG_LOGGING type=bool default=false
+2026/04/15 00:10:22 WARN missing configuration, using default value env_var=ENABLE_JSON_LOGGING type=bool default=false
+2026/04/15 00:10:22 WARN missing configuration, using default value env_var=ENABLE_INSTANCE_ID_LOGGING type=bool default=false
+time=2026-04-15T00:10:22.279Z level=WARN msg="missing configuration, using default value" env_var=HTTP_LISTEN_ADDR type=string default=0.0.0.0:8000
+time=2026-04-15T00:10:22.279Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.279Z level=WARN msg="missing configuration, using default value" env_var=SECRETS_FILE_PATH type=string default=""
+time=2026-04-15T00:10:22.279Z level=ERROR msg="No configuration provided for secret manager path, using a potentially insecure default."
+time=2026-04-15T00:10:22.282Z level=ERROR msg="failed to open secrets file /tmp/tavern-secrets: open /tmp/tavern-secrets: no such file or directory"
+time=2026-04-15T00:10:22.282Z level=ERROR msg="failed to parse YAML file /tmp/tavern-secrets: open /tmp/tavern-secrets: no such file or directory"
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=MYSQL_ADDR type=string default=""
+time=2026-04-15T00:10:22.293Z level=WARN msg="mysql is not configured, using sqlite"
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=OAUTH_CLIENT_ID type=string default=""
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=OAUTH_CLIENT_SECRET type=string default=""
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=OAUTH_DOMAIN type=string default=""
+time=2026-04-15T00:10:22.293Z level=WARN msg="oauth is not configured, authentication disabled"
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=DB_MAX_IDLE_CONNS type=int default=10
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=DB_MAX_OPEN_CONNS type=int default=100
+time=2026-04-15T00:10:22.293Z level=WARN msg="missing configuration, using default value" env_var=DB_MAX_CONN_LIFETIME type=int default=3600
+time=2026-04-15T00:10:22.300Z level=WARN msg="missing configuration, using default value" env_var=DISABLE_DEFAULT_TOMES type=bool default=false
+time=2026-04-15T00:10:22.309Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.309Z level=WARN msg="missing configuration, using default value" env_var=SECRETS_FILE_PATH type=string default=""
+time=2026-04-15T00:10:22.309Z level=ERROR msg="No configuration provided for secret manager path, using a potentially insecure default."
+time=2026-04-15T00:10:22.314Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.314Z level=WARN msg="missing configuration, using default value" env_var=SECRETS_FILE_PATH type=string default=""
+time=2026-04-15T00:10:22.314Z level=ERROR msg="No configuration provided for secret manager path, using a potentially insecure default."
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=ENABLE_TEST_DATA type=bool default=false
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_TOPIC_SHELL_INPUT type=string default=mem://shell_input
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_TOPIC_SHELL_OUTPUT type=string default=mem://shell_output
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_SUBSCRIPTION_SHELL_INPUT type=string default=mem://shell_input
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_SUBSCRIPTION_SHELL_OUTPUT type=string default=mem://shell_output
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_SUBSCRIBER_MAX_MESSAGES_BUFFERED type=int default=15625
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_DELAY_THRESHOLD_MS type=int default=10
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_COUNT_THRESHOLD type=int default=100
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_BYTE_THRESHOLD type=int default=1000000
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_NUM_GOROUTINES type=int default=25
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_TIMEOUT_MS type=int default=1000
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_FLOW_CONTROL_MAX_OUTSTANDING_MESSAGES type=int default=1000
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_FLOW_CONTROL_MAX_OUTSTANDING_BYTES type=int default=-1
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_FLOW_CONTROL_LIMIT_EXCEEDED_BEHAVIOR type=string default=ignore
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_RECEIVE_MAX_EXTENSION_MS type=int default=0
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_RECEIVE_MAX_DURATION_PER_ACK_EXTENSION_MS type=int default=0
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_RECEIVE_MIN_DURATION_PER_ACK_EXTENSION_MS type=int default=0
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_RECEIVE_MAX_OUTSTANDING_MESSAGES type=int default=1000
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_RECEIVE_MAX_OUTSTANDING_BYTES type=int default=-1
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_RECEIVE_NUM_GOROUTINES type=int default=10
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_SUBSCRIPTION_TTL_HOURS type=int default=24
+time=2026-04-15T00:10:22.521Z level=WARN msg="missing configuration, using default value" env_var=PUBSUB_GCP_PUBLISH_READY_TIMEOUT_MS type=int default=0
+time=2026-04-15T00:10:22.524Z level=WARN msg="missing configuration, using default value" env_var=ENABLE_GRAPHQL_RAW_QUERY_LOGGING type=bool default=false
+time=2026-04-15T00:10:22.524Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.524Z level=WARN msg="missing configuration, using default value" env_var=SECRETS_FILE_PATH type=string default=""
+time=2026-04-15T00:10:22.524Z level=ERROR msg="No configuration provided for secret manager path, using a potentially insecure default."
+time=2026-04-15T00:10:22.664Z level=INFO msg="public key: 5WJxIrXVkJcL3ppIlUErgUoOMZTd1UFkJql7WR9bjlY="
+time=2026-04-15T00:10:22.664Z level=WARN msg="missing configuration, using default value" env_var=GCP_PROJECT_ID type=string default=""
+time=2026-04-15T00:10:22.664Z level=WARN msg="missing configuration, using default value" env_var=SECRETS_FILE_PATH type=string default=""
+time=2026-04-15T00:10:22.664Z level=ERROR msg="No configuration provided for secret manager path, using a potentially insecure default."
+time=2026-04-15T00:10:22.710Z level=WARN msg="missing configuration, using default value" env_var=ENABLE_PPROF type=bool default=false
+time=2026-04-15T00:10:22.710Z level=WARN msg="missing configuration, using default value" env_var=ENABLE_METRICS type=bool default=false
+time=2026-04-15T00:10:22.710Z level=WARN msg="missing configuration, using default value" env_var=ENABLE_TEST_RUN_AND_EXIT type=bool default=false
+time=2026-04-15T00:10:22.710Z level=INFO msg="http server started" http_addr=0.0.0.0:8000


### PR DESCRIPTION
This PR adds a "Create Portal" button to the top of the portals tab in the host details page. Clicking this button opens the "Create Quest" modal with the "SOCKS5 Relay" tome pre-selected and the beacons already filtered to the current host. This provides a streamlined workflow for creating portals, similar to the existing "Report File" functionality.

Key changes:
- `VirtualizedTableWrapper`: Added `actions` and `emptyStateAction` props to allow inserting custom buttons into the table header and empty state.
- `CreatePortalQuestButton`: A new component that handles the logic for opening the quest modal with pre-filled data.
- `usePortalQuestFormData`: A custom hook that fetches necessary data (Tome ID, online Beacons) to populate the quest modal.
- `PortalTab`: Updated to include the new button in both the header (for when portals exist) and the empty state.

---
*PR created automatically by Jules for task [9166352739207682382](https://jules.google.com/task/9166352739207682382) started by @KCarretto*