### PR TITLE
Add create shell button to host details shells tab

### DIFF
--- a/tavern/internal/www/src/pages/host-details/shell-tab/ShellTab.tsx
+++ b/tavern/internal/www/src/pages/host-details/shell-tab/ShellTab.tsx
@@ -2,6 +2,7 @@ import { VirtualizedTableWrapper } from "../../../components/tavern-base-ui/virt
 import { ShellsTable } from "./ShellsTable";
 import { useShellIds } from "./useShellIds";
 import { useParams } from "react-router-dom";
+import { CreateShellButton } from "../../../components/create-shell-button/CreateShellButton";
 
 const ShellTab = () => {
     const { hostId } = useParams();
@@ -23,6 +24,7 @@ const ShellTab = () => {
                 loading={initialLoading}
                 error={error}
                 showFiltering={false}
+                actions={<CreateShellButton hostId={hostId} />}
                 table={
                     <ShellsTable
                         shellIds={shellIds}


### PR DESCRIPTION
Added a "Create Shell" button to the Shells tab on the host details page, reusing the existing `CreateShellButton` component for beacon selection logic.

---
*PR created automatically by Jules for task [5113009563923639806](https://jules.google.com/task/5113009563923639806) started by @KCarretto*