### PR TITLE
fix: disable automatic ShellV2 autocomplete on period typing

### DIFF
--- a/tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts
+++ b/tavern/internal/www/src/pages/shellv2/hooks/useShellTerminal.ts
@@ -942,7 +942,7 @@ export const useShellTerminal = (
             }
 
             // Trigger completion updates if needed
-            if (!isPaste && (completionsRef.current.show || code === 46 /* . */)) {
+            if (!isPaste && completionsRef.current.show) {
                 if (state.inputBuffer.endsWith("(") || code === 40 /* ( */) {
                     if (completionsRef.current.show) {
                         updateCompletionsUI([], 0, false, 0);


### PR DESCRIPTION
Removed the condition that automatically triggered the ShellV2 autocomplete when typing a period (`.`) in `useShellTerminal.ts`. The autocomplete will now only trigger explicitly (e.g., Tab or Ctrl+Space), making the shell less intrusive.

---
*PR created automatically by Jules for task [3675389121117113842](https://jules.google.com/task/3675389121117113842) started by @KCarretto*