### PR TITLE
feat: add quiet feature flag to suppress install output

### DIFF
--- a/implants/imix/Cargo.toml
+++ b/implants/imix/Cargo.toml
@@ -16,6 +16,7 @@ icmp = ["transport/icmp"]
 tcp-bind = ["transport/tcp-bind"]
 win_service = []
 install = []
+quiet = []
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 [dependencies]

--- a/implants/imix/src/install.rs
+++ b/implants/imix/src/install.rs
@@ -2,6 +2,8 @@
 use anyhow::Result;
 #[cfg(feature = "install")]
 use eldritch::Interpreter;
+#[cfg(all(feature = "install", feature = "quiet"))]
+use eldritch::NoopPrinter;
 use eldritch::assets::std::{EmbeddedAssets, StdAssetsLibrary};
 use std::sync::Arc;
 
@@ -33,6 +35,10 @@ pub async fn install() -> Result<()> {
             // Execute using Eldritch Interpreter
             let mut locker = StdAssetsLibrary::new();
             let _ = locker.add(asset_backend.clone());
+            #[cfg(feature = "quiet")]
+            let mut interpreter =
+                Interpreter::new_with_printer(Arc::new(NoopPrinter)).with_default_libs();
+            #[cfg(not(feature = "quiet"))]
             let mut interpreter = Interpreter::new().with_default_libs();
             interpreter.register_lib(locker);
 

--- a/implants/lib/eldritch/eldritch-core/src/interpreter/mod.rs
+++ b/implants/lib/eldritch/eldritch-core/src/interpreter/mod.rs
@@ -13,4 +13,4 @@ pub use self::core::Interpreter;
 pub use self::error::EldritchError;
 #[allow(unused_imports)]
 pub use self::error::EldritchErrorKind;
-pub use self::printer::{BufferPrinter, Printer, StdoutPrinter};
+pub use self::printer::{BufferPrinter, NoopPrinter, Printer, StdoutPrinter};

--- a/implants/lib/eldritch/eldritch-core/src/interpreter/printer.rs
+++ b/implants/lib/eldritch/eldritch-core/src/interpreter/printer.rs
@@ -50,6 +50,17 @@ impl Printer for StdoutPrinter {
     }
 }
 
+/// A printer that discards all output.
+/// Useful when interpreter output should be silently dropped.
+#[derive(Debug)]
+pub struct NoopPrinter;
+
+impl Printer for NoopPrinter {
+    fn print_out(&self, _span: &Span, _s: &str) {}
+
+    fn print_err(&self, _span: &Span, _s: &str) {}
+}
+
 /// A printer that writes to an internal string buffer.
 /// Useful for capturing output in tests or REPL environments.
 #[derive(Debug)]

--- a/implants/lib/eldritch/eldritch-core/src/lib.rs
+++ b/implants/lib/eldritch/eldritch-core/src/lib.rs
@@ -17,7 +17,7 @@ pub use analysis::find_node_at_offset;
 pub use ast::{
     Argument, Environment, ExprKind, FStringSegment, ForeignValue, Param, Stmt, StmtKind, Value,
 };
-pub use interpreter::{BufferPrinter, Interpreter, Printer, StdoutPrinter};
+pub use interpreter::{BufferPrinter, Interpreter, NoopPrinter, Printer, StdoutPrinter};
 pub use lexer::Lexer;
 pub use token::{Span, TokenKind};
 

--- a/implants/lib/eldritch/eldritch/src/lib.rs
+++ b/implants/lib/eldritch/eldritch/src/lib.rs
@@ -24,8 +24,8 @@ pub use eldritch_repl as repl;
 
 // Re-export core types
 pub use eldritch_core::{
-    BufferPrinter, Environment, ForeignValue, Interpreter as CoreInterpreter, Printer, Span,
-    StdoutPrinter, TokenKind, Value, conversion,
+    BufferPrinter, Environment, ForeignValue, Interpreter as CoreInterpreter, NoopPrinter, Printer,
+    Span, StdoutPrinter, TokenKind, Value, conversion,
 };
 pub use eldritch_macros as macros;
 


### PR DESCRIPTION
## Summary

- Adds a `quiet` compile-time Cargo feature flag to imix that suppresses all Eldritch `print`/`eprint` output during `./imix install`
- Introduces `NoopPrinter` in `eldritch-core`, a `Printer` implementation that silently discards all output, following the same pattern as `StdoutPrinter` and `BufferPrinter`
- When `--features quiet` is enabled, the install interpreter uses `NoopPrinter` instead of `StdoutPrinter`, so embedded tomes run silently with no terminal output

During `./imix install`, embedded tomes (e.g. `install_service/main.eldritch`) print status messages to stdout via the default `StdoutPrinter`. Imix install stdout might expose how the underlying functionality of the tomes operates for blue teamers if they exfil the imix binary and run it in a sandbox offline. Debug statements are nice to have within the tomes themselves for troubleshooting, but having a functionality at compile-time to go and discard all output would be nice for running `./imix install` in prod quickly without having to comment out all of the debug statements in the eldritch files themselves.

This is a compile-time opt-in (`quiet` is not in the default feature set), so existing builds are unaffected.

## Files Changed

- `implants/lib/eldritch/eldritch-core/src/interpreter/printer.rs` — add `NoopPrinter`
- `implants/lib/eldritch/eldritch-core/src/interpreter/mod.rs` — re-export `NoopPrinter`
- `implants/lib/eldritch/eldritch-core/src/lib.rs` — re-export `NoopPrinter`
- `implants/lib/eldritch/eldritch/src/lib.rs` — re-export `NoopPrinter`
- `implants/imix/Cargo.toml` — add `quiet` feature
- `implants/imix/src/install.rs` — gate printer selection on `quiet` feature
