### PR TITLE
[AI] Expand Test Coverage - http/device_auth

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,38 @@
+--- tavern/internal/http/device_auth_test.go
++++ tavern/internal/http/device_auth_test.go
+@@ -10,6 +10,7 @@
+	"time"
+
+	"realm.pub/tavern/internal/auth"
++	"realm.pub/tavern/internal/ent/deviceauth"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+@@ -198,7 +199,8 @@
+		SetOauthID("auth_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetAccessToken("auth_access_token").
++		SetSessionToken("auth_session_token").
+		SaveX(ctx)
+
+	// Create device auth entries
+@@ -223,7 +225,8 @@
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+-	authCtx := auth.ContextWithUser(ctx, user)
++	authCtx, err := auth.ContextFromSessionToken(ctx, graph, "auth_session_token")
++	require.NoError(t, err)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+@@ -309,7 +312,7 @@
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+-		da, err := graph.DeviceAuth.Query().Where(deviceauth.UserCode("valid_code")).First(ctx)
++		da, err := graph.DeviceAuth.Query().Where(deviceauth.UserCode("valid_code")).First(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "APPROVED", string(da.Status))
+	})

--- a/tavern/internal/http/device_auth_test.go
+++ b/tavern/internal/http/device_auth_test.go
@@ -1,0 +1,481 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"realm.pub/tavern/internal/auth"
+	"realm.pub/tavern/internal/ent/deviceauth"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"realm.pub/tavern/internal/ent/enttest"
+	tavernhttp "realm.pub/tavern/internal/http"
+)
+
+func TestNewRDACodeHandler(t *testing.T) {
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDACodeHandler(graph)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp tavernhttp.RDACodeResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, resp.UserCode)
+		assert.NotEmpty(t, resp.DeviceCode)
+		assert.NotEmpty(t, resp.VerificationURI)
+		assert.NotEmpty(t, resp.VerificationURIComplete)
+		assert.Equal(t, 600, resp.ExpiresIn)
+
+		// Verify it was created in the DB
+		da, err := graph.DeviceAuth.Query().First(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, resp.UserCode, da.UserCode)
+		assert.Equal(t, resp.DeviceCode, da.DeviceCode)
+		assert.Equal(t, "PENDING", string(da.Status))
+		assert.WithinDuration(t, time.Now().Add(10*time.Minute), da.ExpiresAt, 5*time.Second)
+	})
+}
+
+func TestNewRDATokenHandler(t *testing.T) {
+	ctx := context.Background()
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDATokenHandler(graph)
+
+	// Create user
+	graph.User.Create().
+		SetName("test_user").
+		SetOauthID("test_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetAccessToken("test_access_token").
+		SaveX(ctx)
+
+	// Create device auth entries
+	graph.DeviceAuth.Create().
+		SetUserCode("expired_user").
+		SetDeviceCode("expired_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(-10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("pending_user").
+		SetDeviceCode("pending_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("approved_nouser_user").
+		SetDeviceCode("approved_nouser_device").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("approved_user").
+		SetDeviceCode("approved_device").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SetUser(graph.User.Query().FirstX(ctx)).
+		SaveX(ctx)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("MissingDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("InvalidDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=invalid", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("ExpiredDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=expired_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PendingDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=pending_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp tavernhttp.RDATokenResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "PENDING", resp.Status)
+		assert.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("ApprovedNoUser", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=approved_nouser_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("ApprovedWithUser", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=approved_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp tavernhttp.RDATokenResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "APPROVED", resp.Status)
+		assert.Equal(t, "test_access_token", resp.AccessToken)
+	})
+}
+
+func TestNewRDAApproveHandler(t *testing.T) {
+	ctx := context.Background()
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDAApproveHandler(graph)
+
+	// Create a user for auth context
+	graph.User.Create().
+		SetName("auth_user").
+		SetOauthID("auth_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetAccessToken("auth_access_token").
+		SetSessionToken("auth_session_token").
+		SaveX(ctx)
+
+	// Create device auth entries
+	graph.DeviceAuth.Create().
+		SetUserCode("expired_code").
+		SetDeviceCode("expired_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(-10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("already_approved").
+		SetDeviceCode("already_device").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("valid_code").
+		SetDeviceCode("valid_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	authCtx, err := auth.ContextFromSessionToken(ctx, graph, "auth_session_token")
+	require.NoError(t, err)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString("invalid json"))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("MissingUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Unauthenticated", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "valid_code"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("InvalidUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "invalid"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("ExpiredUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "expired_code"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("NotPending", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "already_approved"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "valid_code"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		da, err := graph.DeviceAuth.Query().Where(deviceauth.UserCode("valid_code")).First(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "APPROVED", string(da.Status))
+	})
+}
+
+func TestNewRDARevokeHandler(t *testing.T) {
+	ctx := context.Background()
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDARevokeHandler(graph)
+
+	// Create user
+	user := graph.User.Create().
+		SetName("test_user").
+		SetOauthID("test_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetSessionToken("test_session_token").
+		SaveX(ctx)
+
+	otherUser := graph.User.Create().
+		SetName("other_user").
+		SetOauthID("other_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetSessionToken("other_session_token").
+		SaveX(ctx)
+
+	graph.User.Create().
+		SetName("admin_user").
+		SetOauthID("admin_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetIsAdmin(true).
+		SetSessionToken("admin_session_token").
+		SaveX(ctx)
+
+	// Create device auth entries
+	graph.DeviceAuth.Create().
+		SetUserCode("my_device").
+		SetDeviceCode("my_device_code").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SetUser(user).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("other_device").
+		SetDeviceCode("other_device_code").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SetUser(otherUser).
+		SaveX(ctx)
+
+	userCtx, err := auth.ContextFromSessionToken(ctx, graph, "test_session_token")
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+
+	adminUserCtx, err := auth.ContextFromSessionToken(ctx, graph, "admin_session_token")
+	require.NoError(t, err)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString("invalid json"))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Unauthenticated", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "my_device"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("InvalidUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "invalid"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(userCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("Unauthorized_OtherUserDevice", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "other_device"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(userCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("Success_OwnDevice", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "my_device"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(userCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		da, err := graph.DeviceAuth.Query().Where(deviceauth.UserCode("my_device")).First(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "DENIED", string(da.Status))
+	})
+
+	t.Run("Success_AdminRevokeOther", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "other_device"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(adminUserCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		da, err := graph.DeviceAuth.Query().Where(deviceauth.UserCode("other_device")).First(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "DENIED", string(da.Status))
+	})
+}
+
+func TestNewSignoutHandler(t *testing.T) {
+	handler := tavernhttp.NewSignoutHandler()
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Header().Get("Set-Cookie"), "auth-session=")
+	})
+}

--- a/tavern/internal/http/device_auth_test.go.orig
+++ b/tavern/internal/http/device_auth_test.go.orig
@@ -1,0 +1,315 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"realm.pub/tavern/internal/auth"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"realm.pub/tavern/internal/ent/enttest"
+	tavernhttp "realm.pub/tavern/internal/http"
+)
+
+func TestNewRDACodeHandler(t *testing.T) {
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDACodeHandler(graph)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp tavernhttp.RDACodeResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, resp.UserCode)
+		assert.NotEmpty(t, resp.DeviceCode)
+		assert.NotEmpty(t, resp.VerificationURI)
+		assert.NotEmpty(t, resp.VerificationURIComplete)
+		assert.Equal(t, 600, resp.ExpiresIn)
+
+		// Verify it was created in the DB
+		da, err := graph.DeviceAuth.Query().First(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, resp.UserCode, da.UserCode)
+		assert.Equal(t, resp.DeviceCode, da.DeviceCode)
+		assert.Equal(t, "PENDING", string(da.Status))
+		assert.WithinDuration(t, time.Now().Add(10*time.Minute), da.ExpiresAt, 5*time.Second)
+	})
+}
+
+func TestNewRDATokenHandler(t *testing.T) {
+	ctx := context.Background()
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDATokenHandler(graph)
+
+	// Create user
+	user := graph.User.Create().
+		SetName("test_user").
+		SetOauthID("test_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetAccessToken("test_access_token").
+		SaveX(ctx)
+
+	// Create device auth entries
+	graph.DeviceAuth.Create().
+		SetUserCode("expired_user").
+		SetDeviceCode("expired_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(-10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("pending_user").
+		SetDeviceCode("pending_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("approved_nouser_user").
+		SetDeviceCode("approved_nouser_device").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("approved_user").
+		SetDeviceCode("approved_device").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SetUser(user).
+		SaveX(ctx)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("MissingDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("InvalidDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=invalid", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("ExpiredDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=expired_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PendingDeviceCode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=pending_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp tavernhttp.RDATokenResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "PENDING", resp.Status)
+		assert.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("ApprovedNoUser", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=approved_nouser_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("ApprovedWithUser", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?device_code=approved_device", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp tavernhttp.RDATokenResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "APPROVED", resp.Status)
+		assert.Equal(t, "test_access_token", resp.AccessToken)
+	})
+}
+
+func TestNewRDAApproveHandler(t *testing.T) {
+	ctx := context.Background()
+	graph := enttest.OpenTempDB(t)
+	defer graph.Close()
+
+	handler := tavernhttp.NewRDAApproveHandler(graph)
+
+	// Create a user for auth context
+	user := graph.User.Create().
+		SetName("auth_user").
+		SetOauthID("auth_oauth").
+		SetPhotoURL("http://example.com").
+		SetIsActivated(true).
+		SetAccessToken("auth_access_token").
+		SaveX(ctx)
+
+	// Create device auth entries
+	graph.DeviceAuth.Create().
+		SetUserCode("expired_code").
+		SetDeviceCode("expired_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(-10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("already_approved").
+		SetDeviceCode("already_device").
+		SetStatus("APPROVED").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	graph.DeviceAuth.Create().
+		SetUserCode("valid_code").
+		SetDeviceCode("valid_device").
+		SetStatus("PENDING").
+		SetExpiresAt(time.Now().Add(10 * time.Minute)).
+		SaveX(ctx)
+
+	authCtx := auth.ContextWithUser(ctx, user)
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString("invalid json"))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("MissingUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Unauthenticated", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "valid_code"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("InvalidUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "invalid"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("ExpiredUserCode", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "expired_code"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("NotPending", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "already_approved"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		reqBody := tavernhttp.RDAApproveRequest{UserCode: "valid_code"}
+		bodyBytes, _ := json.Marshal(reqBody)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes)).WithContext(authCtx)
+		w := httptest.NewRecorder()
+
+		handler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		da, err := graph.DeviceAuth.Query().Where(deviceauth.UserCode("valid_code")).First(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "APPROVED", string(da.Status))
+	})
+}


### PR DESCRIPTION
This PR expands the test coverage for the `tavern/internal/http` module, specifically targeting the previously untested functions inside `device_auth.go`.

**Changes**
*   Created `tavern/internal/http/device_auth_test.go`.
*   Added `TestNewRDACodeHandler` to check successful generation of Device Code and Validation URI along with initial state setup.
*   Added `TestNewRDATokenHandler` to cover token generation, token request lifecycle scenarios (Expired, Pending, Approved), and missing/invalid variables edge cases.
*   Added `TestNewRDAApproveHandler` for the flow covering user authentication verifications. It checks user scope and ensures the state of DB matches after a successful user approval process.
*   Added `TestNewRDARevokeHandler` focusing mainly on authorization (admin context verifications) and general denial edge cases.
*   Added `TestNewSignoutHandler` validating the `auth-session` cookie termination.

**Verification**
*   Tests verified using `go test ./tavern/internal/http/...` 
*   Verified zero flaky behaviors by running tests exactly 20 times iteratively.
*   Confirmed a significant test coverage increase across the module via `go tool cover`.

---
*PR created automatically by Jules for task [15539849977357684945](https://jules.google.com/task/15539849977357684945) started by @KCarretto*