### PR TITLE
Update documentation for QUIC transport and redirector

### DIFF
--- a/docs/_docs/admin-guide/tavern.md
+++ b/docs/_docs/admin-guide/tavern.md
@@ -110,10 +110,11 @@ By default Tavern only supports gRPC connections directly to the server. To enab
 
 ### Available Redirectors
 
-Realm includes four built-in redirector implementations:
+Realm includes five built-in redirector implementations:
 
 - **`grpc`** - Direct gRPC passthrough redirector
 - **`http1`** - HTTP/1.1 to gRPC redirector
+- **`quic`** - UDP-based QUIC redirector
 - **`dns`** - DNS to gRPC redirector
 - **`icmp`** - ICMP Echo to gRPC redirector
 
@@ -130,6 +131,17 @@ Start a redirector:
 ```bash
 tavern redirector --transport <TRANSPORT> --listen <LISTEN_ADDR> <UPSTREAM_GRPC_ADDR>
 ```
+
+### QUIC Redirector
+
+The QUIC redirector accepts UDP-based QUIC traffic from agents and forwards it to an upstream gRPC server.
+
+```bash
+# Start QUIC redirector on UDP port 8443
+tavern redirector --transport quic --listen ":8443" localhost:8000
+```
+
+Unlike some of the other redirectors (such as HTTP/1.1 or DNS), the QUIC redirector supports bidirectional streaming, enabling features such as SOCKS5 proxies or interactive reverse shells. It will generate a self-signed TLS certificate if none is provided.
 
 ### HTTP/1.1 Redirector
 

--- a/docs/_docs/dev-guide/imix.md
+++ b/docs/_docs/dev-guide/imix.md
@@ -149,10 +149,11 @@ We've tried to make Imix super extensible for transport development. In fact, al
 
 ### Current Available Transports
 
-Realm currently includes three transport implementations:
+Realm currently includes four transport implementations:
 
 - **`grpc`** - Default gRPC transport
 - **`http1`** - HTTP/1.1 transport
+- **`quic`** - QUIC-based transport
 - **`dns`** - DNS-based covert channel transport
 - **`icmp`** - ICMP-based covert channel transport
 
@@ -311,6 +312,7 @@ For your agent to communicate, you'll need to implement a corresponding redirect
 
 - `tavern/internal/redirectors/grpc/` - gRPC redirector
 - `tavern/internal/redirectors/http1/` - HTTP/1.1 redirector
+- `tavern/internal/redirectors/quic/` - QUIC redirector
 - `tavern/internal/redirectors/dns/` - DNS redirector
 - `tavern/internal/redirectors/icmp/` - ICMP redirector
 

--- a/docs/_docs/user-guide/imix.md
+++ b/docs/_docs/user-guide/imix.md
@@ -191,7 +191,7 @@ cargo build --release --bin imix --target=x86_64-unknown-linux-musl
 
 ## Transport configuration
 
-Imix supports pluggable transports making it easy to adapt to your environment. Out of the box it supports `grpc` (default), `http1`, `dns`, and `icmp`. Each transport has a corresponding redirector subcommand in tavern. In order to use a non grpc transport a redirector that can speak to your transport is required.
+Imix supports pluggable transports making it easy to adapt to your environment. Out of the box it supports `grpc` (default), `http1`, `quic`, `dns`, and `icmp`. Each transport has a corresponding redirector subcommand in tavern. In order to use a non grpc transport a redirector that can speak to your transport is required.
 
 ### global configuration options
 - `uri`: specifies the upstream server or redirector the agent should connect to eg. `https://example.com` custom ports can be specified as `https://example.com:8443`
@@ -220,6 +220,15 @@ The HTTP1 transport uses HTTP post requests to communicate to the redirector.
 
 
 This transport doesn't support eldritch functions that require bi-directional streaming like reverse shell, or SOCKS5 proxying.
+
+
+### quic
+
+The QUIC transport uses QUIC/UDP (via `realm-quic` ALPN) to communicate to the redirector/server.
+
+This transport supports all eldritch functions, including those that require bi-directional streaming like reverse shell, or SOCKS5 proxying.
+
+**Extra Keys Supported:** None
 
 
 ### dns


### PR DESCRIPTION
This PR updates the user, administrator, and developer guides to document the new QUIC-based transport protocol and its redirector.