### PR TITLE
[AI] Update Dependency - spin

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -130,7 +130,7 @@ serde_yaml = "0.9"
 sha1 = "0.10.5"
 sha2 = "0.10.7"
 sha256 = { version = "1.0.3", default-features = false }
-spin = { version = "0.10.0", features = ["mutex", "spin_mutex", "rwlock"] }
+spin = { version = "0.12.0", features = ["mutex", "spin_mutex", "rwlock"] }
 starlark = "0.12.0"
 starlark_derive = "0.12.0"
 structopt = "0.3.23"

--- a/implants/lib/eldritch/eldritch/Cargo.toml
+++ b/implants/lib/eldritch/eldritch/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2024"
 
 [dependencies]
-spin = "0.10"
+spin = "0.12"
 
 eldritch-core = { workspace = true, default-features = false }
 eldritch-macros = { workspace = true }

--- a/implants/lib/eldritch/stdlib/eldritch-libagent/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libagent/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = { workspace = true, optional = true }
 pb = { path = "../../../pb", optional = true }
 prost = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
-spin = { version = "0.10.0", features = ["rwlock"] }
+spin = { version = "0.12.0", features = ["rwlock"] }
 
 [features]
 default = ["stdlib"]

--- a/implants/lib/eldritch/stdlib/eldritch-libcrypto/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libcrypto/Cargo.toml
@@ -20,7 +20,7 @@ fake_bindings = []
 [dependencies]
 eldritch-core = { workspace = true }
 eldritch-macros = { workspace = true }
-spin = { version = "0.10.0", features = ["rwlock"] }
+spin = { version = "0.12.0", features = ["rwlock"] }
 aes = { workspace = true, optional = true }
 md5 = { workspace = true, optional = true }
 sha1 = { workspace = true, optional = true }

--- a/implants/lib/eldritch/stdlib/eldritch-libfile/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libfile/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
-spin = { version = "0.10.0", features = ["mutex", "spin_mutex"] }
+spin = { version = "0.12.0", features = ["mutex", "spin_mutex"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["user", "fs"] }

--- a/implants/lib/eldritch/stdlib/eldritch-libhttp/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libhttp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 eldritch-core = { workspace = true }
 eldritch-macros = { workspace = true }
-spin = { version = "0.10.0", features = ["rwlock"] }
+spin = { version = "0.12.0", features = ["rwlock"] }
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
     "rustls-tls",

--- a/implants/lib/eldritch/stdlib/eldritch-libprocess/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libprocess/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 eldritch-core = { workspace = true }
 eldritch-macros = { workspace = true }
 sysinfo = { workspace = true, optional = true }
-spin = { version = "0.10.0", features = ["mutex", "spin_mutex"] }
+spin = { version = "0.12.0", features = ["mutex", "spin_mutex"] }
 netstat = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/implants/lib/eldritch/stdlib/eldritch-libreport/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libreport/Cargo.toml
@@ -9,7 +9,7 @@ eldritch-macros = { workspace = true }
 eldritch-agent = { workspace = true, optional = true }
 pb = { workspace = true, optional = true }
 nix = { workspace = true, optional = true }
-spin = { version = "0.10.0", features = ["rwlock"] }
+spin = { version = "0.12.0", features = ["rwlock"] }
 glob = { workspace = true }
 log = { workspace = true }
 

--- a/implants/lib/eldritch/stdlib/eldritch-libsys/Cargo.toml
+++ b/implants/lib/eldritch/stdlib/eldritch-libsys/Cargo.toml
@@ -11,7 +11,7 @@ sysinfo = { workspace = true, optional = true }
 whoami = { workspace = true, optional = true }
 local-ip-address = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
-spin = { version = "0.10.0", features = ["mutex", "spin_mutex"] }
+spin = { version = "0.12.0", features = ["mutex", "spin_mutex"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true }


### PR DESCRIPTION
Updates `spin` from `0.10.0` to `0.12.0` across the implants workspace.
Ran `cargo upgrade -p spin --incompatible` to handle all occurrences.
Verified the build via `cargo build --all-targets` and `cargo test` using the required `IMIX_SERVER_PUBKEY` compile-time environment variable.
No features were dropped and transitive dependencies updated successfully.

---
*PR created automatically by Jules for task [6620906710124330801](https://jules.google.com/task/6620906710124330801) started by @KCarretto*