### PR TITLE
[AI] Update Dependency - tera

### DIFF
--- a/implants/Cargo.toml
+++ b/implants/Cargo.toml
@@ -137,7 +137,7 @@ structopt = "0.3.23"
 sysinfo = { version = "0.29.7", default-features = false }
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.20.0"
-tera = { version = "1.17.1", default-features = false }
+tera = { version = "1.20.1", default-features = false }
 thiserror = "1.0.30"
 tokio = "1.49.0"
 tokio-stream = { version = "0.1.9", default-features = false }


### PR DESCRIPTION
This PR updates the `tera` dependency to its latest version (v1.20.1) using `cargo upgrade -p tera --incompatible` to enhance security and stability.

---
*PR created automatically by Jules for task [6780208596171136446](https://jules.google.com/task/6780208596171136446) started by @KCarretto*