### PR TITLE
[AI] Update Dependency - walkdir

### DIFF
--- a/implants/lib/eldritch/eldritch/Cargo.toml
+++ b/implants/lib/eldritch/eldritch/Cargo.toml
@@ -91,4 +91,4 @@ httptest = "0.16"
 
 [build-dependencies]
 regex = "1.10"
-walkdir = "2.3"
+walkdir = "2.5"


### PR DESCRIPTION
This PR updates exactly one outdated direct dependency in the repository: `walkdir` from version `2.3` to `2.5`. It targets the `implants/lib/eldritch/eldritch/Cargo.toml` file.

- Checked for open PRs for `walkdir` before selecting it.
- Tested by running `cargo build --all-targets` and `cargo test --all-targets` inside the `implants` directory, which were successful.
- Adhered to the single target scope requirement.

---
*PR created automatically by Jules for task [7792838285452020776](https://jules.google.com/task/7792838285452020776) started by @KCarretto*