### PR TITLE
Fix failing CI by installing libpam0g-dev

### DIFF
--- a/.github/workflows/e2e-asset-execution.yml
+++ b/.github/workflows/e2e-asset-execution.yml
@@ -38,7 +38,7 @@ jobs:
     - name: 📦 Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgbm-dev libx11-dev libssl-dev protobuf-compiler pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev
+        sudo apt-get install -y libgbm-dev libx11-dev libssl-dev protobuf-compiler pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libpam0g-dev
     - name: 🔨 Build Tavern
       run: |
         go mod download

--- a/.github/workflows/e2e-portals.yml
+++ b/.github/workflows/e2e-portals.yml
@@ -38,7 +38,7 @@ jobs:
     - name: 📦 Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgbm-dev libx11-dev libssl-dev protobuf-compiler pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev jq
+        sudo apt-get install -y libgbm-dev libx11-dev libssl-dev protobuf-compiler pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev jq libpam0g-dev
 
 
     - name: 🔨 Build Tavern & Socks5

--- a/.github/workflows/e2e-repl-test.yml
+++ b/.github/workflows/e2e-repl-test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: 📦 Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgbm-dev libx11-dev libssl-dev protobuf-compiler pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev
+        sudo apt-get install -y libgbm-dev libx11-dev libssl-dev protobuf-compiler pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libpam0g-dev
 
     - name: 🔨 Build Tavern
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: 📦 Install System Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpam0g-dev
       - name: 🔨 Build
         run: go build -ldflags='-w -extldflags "-static"' -o ${{ runner.temp }}/realm_build/tavern ./tavern
       - name: 🌥️⬆️ Upload Assets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
       with:
         go-version-file: go.mod
         cache: true
+    - name: 📦 Install System Dependencies
+      run: sudo apt-get update && sudo apt-get install -y libpam0g-dev
     - name: 🔨 Install Tools
       run: |
         # Use latest gotestsum, Go 1.25.0 supports it


### PR DESCRIPTION
The repository has a dependency on `github.com/msteinert/pam/v2` which requires PAM development headers to compile via CGO. Several GitHub Actions workflows running on Ubuntu were failing to build or test the Go codebase due to missing `security/pam_appl.h`.

This commit adds `sudo apt-get install -y libpam0g-dev` to the system dependency installation steps across multiple CI workflow files (`tests.yml`, `e2e-portals.yml`, `e2e-repl-test.yml`, `e2e-asset-execution.yml`, and `release.yml`) to ensure successful compilation.

---
*PR created automatically by Jules for task [9798069546321409085](https://jules.google.com/task/9798069546321409085) started by @hulto*